### PR TITLE
use new data browser

### DIFF
--- a/src/pages/BrowserPage/BrowserPage.js
+++ b/src/pages/BrowserPage/BrowserPage.js
@@ -45,8 +45,9 @@ class BrowserPage extends Component {
 			url: `https://${credentials}@scalr.api.appbase.io`,
 			appname: appName,
 		};
-		const url = JSON.stringify(dejavu);
-		const iframeURL = `https://opensource.appbase.io/dejavu/live/#?app=${url}&hf=false&subscribe=false`;
+		const iframeURL = `https://dejavu.appbase.io/?appname=${dejavu.appname}&url=${
+			dejavu.url
+		}&footer=false&sidebar=false&appswitcher=false&mode=edit`;
 
 		return (
 			<section>


### PR DESCRIPTION
This should be merged after a bug in dejavu is resolved which causes an error when rendering it with an appbase.io app that has no data but some mappings.

You can check if this bug is resolved by going to https://dejavu.appbase.io/?appname=2a-recon&url=https://v84m1HFo6:1fc22a37-af57-48c9-91c8-8905a7cd4d33@scalr.api.appbase.io&footer=false&mode=edit.

But as soon as that is and you are able to test with apps on your accounts, we should switch to this version as it significantly improves usability, and handles certain error scenarios better than the older version.