### PR TITLE
fix: remove southamerica-east1 support

### DIFF
--- a/src/pages/ClusterPage/utils/regions.js
+++ b/src/pages/ClusterPage/utils/regions.js
@@ -25,11 +25,6 @@ export const regions = {
 		'us-east1': { name: 'South Carolina', flag: 'united-states.png', continent: 'us' },
 		'us-central1': { name: 'Iowa', flag: 'united-states.png', continent: 'us' },
 		'us-east4': { name: 'N. Virginia', flag: 'united-states.png', continent: 'us' },
-		'southamerica-east1': {
-			name: 'Sao Paulo',
-			flag: 'brazil.png',
-			continent: 'us',
-		},
 		'northamerica-northeast1': {
 			name: 'Montreal',
 			flag: 'canada.png',


### PR DESCRIPTION
`soutchamerica-east1` doesn't support n1 / e2 machines so removing support for now.