### PR TITLE
fix: blacklist localhost from link checker

### DIFF
--- a/scripts/site-checker.js
+++ b/scripts/site-checker.js
@@ -23,6 +23,7 @@ async function checkSite() {
 	const result = await checker.check({
 		path: isProduction ? process.env.URL : 'http://localhost:1357',
 		recurse: true,
+		linksToSkip: ['http://localhost:1357'],
 	});
 
 	// How many links did we scan?


### PR DESCRIPTION
## What is this PR for?
blacklist `localhost:1357` from link checking

## How have you tested this PR?
this commit ran without `localhost` running and the tests passed

![](https://i.imgur.com/hlwC6bN.png)

