### PR TITLE
fix: disable es version selection for ansible clusters

### DIFF
--- a/src/pages/ClusterPage/new.js
+++ b/src/pages/ClusterPage/new.js
@@ -1056,6 +1056,7 @@ class NewCluster extends Component {
 										>
 											Select a version
 										</h4>
+										{/* TODO remove disabled fix after we release support for multiple versions on ansible clusters */}
 										<select
 											className="form-control"
 											onChange={e =>
@@ -1064,6 +1065,9 @@ class NewCluster extends Component {
 													e.target.value,
 												)
 											}
+											disabled={hasAnsibleSetup(
+												this.state.pricing_plan,
+											)}
 										>
 											{versions.map(version => (
 												<option


### PR DESCRIPTION
## What is this PR for?

<!-- Brief description of feature / bug fix that this PR do. -->

<!--  Link to Notion card / Github issue -->
* Disable es version selection for sandbox, starter, hobby clusters

## How have you tested this PR?

https://www.loom.com/share/f4bdf3c1200f4375aac7e0905bff8962

<!-- Share the steps that you have followed to test this PR. Add loom video / gif / screenshot -->

## What pages does it affect

<!-- List the pages that this PR can affect. If it is global change, try to add any side effects that it could have -->
