### PR TITLE
fix: stripe key on cluster billing page

### DIFF
--- a/src/pages/BillingPage/index.js
+++ b/src/pages/BillingPage/index.js
@@ -72,7 +72,7 @@ class Billing extends Component {
 									<p>You are currently in trial mode.</p>
 								) : null}
 								<Stripe
-									stripeKey={STRIPE_KEY.TEST}
+									stripeKey={STRIPE_KEY.LIVE}
 									panelLabel="Update Payment"
 									token={updatePayment}
 								>


### PR DESCRIPTION
## What is this PR for?

<!-- Brief description of feature / bug fix that this PR do. -->

<!--  Link to Notion card / Github issue -->

* Sets the stripe payment key to live key in cluster billing page.

## How have you tested this PR?

<!-- Share the steps that you have followed to test this PR. Add loom video / gif / screenshot -->

## What pages does it affect

<!-- List the pages that this PR can affect. If it is global change, try to add any side effects that it could have -->
