### PR TITLE
fix: add deprecation warning to apps popup

### DIFF
--- a/src/components/FullHeader/FullHeader.js
+++ b/src/components/FullHeader/FullHeader.js
@@ -60,6 +60,7 @@ const link = css`
 
 const FullHeader = ({
 	user,
+	apps,
 	cluster,
 	isUsingTrial,
 	isUsingClusterTrial,
@@ -93,9 +94,11 @@ const FullHeader = ({
 					</Menu.Item>
 				) : null}
 
-				<Menu.Item key="/apps">
-					<Link to="/apps">Apps</Link>
-				</Menu.Item>
+				{apps && Boolean(Object.keys(apps).length) && (
+					<Menu.Item key="/apps">
+						<Link to="/apps">Apps</Link>
+					</Menu.Item>
+				)}
 
 				<Menu.Item key="/marketplace">
 					<Link to="/marketplace">
@@ -149,6 +152,7 @@ FullHeader.defaultProps = {
 
 FullHeader.propTypes = {
 	user: object.isRequired,
+	apps: object,
 	cluster: string,
 	clusters: array,
 	currentApp: string.isRequired,
@@ -166,8 +170,10 @@ const mapStateToProps = state => {
 	if (storedApp) {
 		currentApp = storedApp;
 	}
+
 	return {
 		user: get(state, 'user.data'),
+		apps: get(state, 'appsOwners.data'),
 		isUsingTrial: get(state, '$getUserPlan.trial') || false,
 		isUsingClusterTrial: get(state, '$getUserPlan.cluster_trial') || false,
 		daysLeft: get(state, '$getUserPlan.daysLeft', 0),

--- a/src/pages/HomePage/CreateAppModal.js
+++ b/src/pages/HomePage/CreateAppModal.js
@@ -10,6 +10,8 @@ import {
 	List,
 	Popover,
 	notification,
+	Tag,
+	Tooltip,
 } from 'antd';
 import get from 'lodash/get';
 import { Link } from 'react-router-dom';
@@ -213,7 +215,43 @@ class CreateAppModal extends Component {
 				destroyOnClose
 				okButtonProps={{ loading: createdApp.isLoading }}
 				okText="Create App"
-				title="Create App"
+				title={
+					<div
+						style={{
+							color: 'rgba(0, 0, 0, 0.85)',
+							fontWeight: 500,
+							fontSize: '16px',
+							lineHeight: '22px',
+							display: 'flex',
+							alignItems: 'center',
+						}}
+					>
+						Create App
+						<Tooltip
+							title={
+								<span>
+									Creating apps is deprecated. We recommend
+									creating a cluster instead. Read more{' '}
+									<a
+										target="_blank"
+										rel="noopener noreferrer"
+										href="https://appbase.io/migrate-to-clusters"
+									>
+										here
+									</a>
+									.
+								</span>
+							}
+						>
+							<Tag
+								color="red"
+								style={{ marginLeft: 20, cursor: 'pointer' }}
+							>
+								<Icon type="warning" /> Deprecated
+							</Tag>
+						</Tooltip>
+					</div>
+				}
 				onCancel={this.handleCancel}
 				width={600}
 			>
@@ -227,10 +265,7 @@ class CreateAppModal extends Component {
 							}}
 							theme="filled"
 						/>
-						<span>
-							Alternatively, you can also create a dedicated
-							cluster.
-						</span>
+						<span>You should create cluster instead.</span>
 					</div>
 					<Link to="/">Create a Cluster</Link>
 				</section>
@@ -305,22 +340,6 @@ class CreateAppModal extends Component {
 								calls: '100K API calls',
 							})}
 						</Radio>
-						<Radio value="bootstrap" className={pricebtn}>
-							{this.generateGrid({
-								type: 'Bootstrap',
-								price: '$29 per month',
-								records: '100K records',
-								calls: '1M API calls',
-							})}
-						</Radio>
-						<Radio value="growth" className={pricebtn}>
-							{this.generateGrid({
-								type: 'Growth',
-								price: '$89 per month',
-								records: '1M records',
-								calls: '10M API calls',
-							})}
-						</Radio>
 					</RadioGroup>
 				</div>
 
@@ -342,26 +361,6 @@ class CreateAppModal extends Component {
 						</Radio>
 					</RadioGroup>
 				</div>
-
-				<Row>
-					<Col span={14}>
-						<h3 className={modalHeading}>
-							Pick Your Elasticsearch Version
-						</h3>
-						<RadioGroup
-							value={elasticVersion}
-							name="elasticVersion"
-							onChange={this.handleChange}
-						>
-							<Radio className={radiobtn} value="5">
-								5
-							</Radio>
-							<Radio className={radiobtn} value="7">
-								7
-							</Radio>
-						</RadioGroup>
-					</Col>
-				</Row>
 			</Modal>
 		);
 	}

--- a/src/pages/HomePage/HomePage.js
+++ b/src/pages/HomePage/HomePage.js
@@ -67,7 +67,7 @@ class HomePage extends Component {
 			history.push('/tutorial');
 		}
 
-		if (!appsOwners.isFetching && !getAppsOwners.data) {
+		if (!appsOwners.isFetching && !appsOwners.data) {
 			getAppsOwners();
 		}
 		if (!permissions) {


### PR DESCRIPTION
## What is this PR for?

* add deprecation warning for apps
* remove bootstrap + growth plans
* fix the es version to 7
* remove apps menu item for new user / user without apps



## How have you tested this PR?

<img width="1440" alt="Screenshot 2020-08-17 at 5 56 26 PM" src="https://user-images.githubusercontent.com/6964334/90396463-e2610b80-e0b3-11ea-9e27-ed17a1943ddd.png">


## What pages does it affect

<!-- List the pages that this PR can affect. If it is global change, try to add any side effects that it could have -->
