### PR TITLE
fix: remove hasAnsible util

### DIFF
--- a/src/pages/ClusterPage/ClusterPage.js
+++ b/src/pages/ClusterPage/ClusterPage.js
@@ -21,7 +21,6 @@ import {
 	deleteCluster,
 	EFFECTIVE_PRICE_BY_PLANS,
 	getClusters,
-	hasAnsibleSetup,
 	PLAN_LABEL,
 } from './utils';
 import { regions } from './utils/regions';
@@ -85,10 +84,8 @@ class ClusterPage extends Component {
 	};
 
 	getFromPricing = (plan, key, provider = 'azure') => {
-		let allMarks = get(machineMarks, provider);
-		if (hasAnsibleSetup(plan)) {
-			allMarks = get(ansibleMachineMarks, provider);
-		}
+		const allMarks = get(ansibleMachineMarks, provider);
+
 		const selectedPlan = Object.values(allMarks).find(
 			item =>
 				get(item, 'plan') === plan ||
@@ -197,11 +194,7 @@ class ClusterPage extends Component {
 		const { isUsingClusterTrial } = this.props;
 		const { showStripeModal, currentCluster } = this.state;
 		const isExternalCluster = get(cluster, 'recipe') === 'byoc';
-		let allMarks = get(machineMarks, 'gke');
-
-		if (hasAnsibleSetup(cluster.pricing_plan)) {
-			allMarks = ansibleMachineMarks.gke;
-		}
+		let allMarks = ansibleMachineMarks.gke;
 
 		// override plans for byoc cluster
 		if (isExternalCluster) {

--- a/src/pages/ClusterPage/new.js
+++ b/src/pages/ClusterPage/new.js
@@ -16,7 +16,6 @@ import {
 	createSubscription,
 	deployCluster,
 	getClusters,
-	hasAnsibleSetup,
 	CLUSTER_PLANS,
 	PLAN_LABEL,
 	EFFECTIVE_PRICE_BY_PLANS,
@@ -1078,47 +1077,6 @@ class NewCluster extends Component {
 											for ElasticSearch.
 										</p>
 									</div>
-									{!hasAnsibleSetup(
-										this.state.pricing_plan,
-									) && (
-										<div className={esContainer}>
-											<Button
-												size="large"
-												type={
-													this.state.visualization ===
-													'grafana'
-														? 'primary'
-														: 'default'
-												}
-												css={{
-													height: 160,
-													width: '100%',
-													backgroundColor:
-														this.state
-															.visualization ===
-														'grafana'
-															? '#eaf5ff'
-															: '#fff',
-												}}
-												onClick={() => {
-													this.setConfig(
-														'visualization',
-														'grafana',
-													);
-												}}
-											>
-												<img
-													width={120}
-													src="/static/images/clusters/grafana.png"
-													alt="Grafana"
-												/>
-											</Button>
-											<p>
-												The leading open - source tool
-												for metrics visualization.
-											</p>
-										</div>
-									)}
 								</div>
 							</div>
 							{/* this.renderPlugins() */}

--- a/src/pages/ClusterPage/screens/ClusterScreen.js
+++ b/src/pages/ClusterPage/screens/ClusterScreen.js
@@ -18,7 +18,6 @@ import {
 	getClusters,
 	getSnapshots,
 	hasAddon,
-	hasAnsibleSetup,
 	restore,
 	PLAN_LABEL,
 	EFFECTIVE_PRICE_BY_PLANS,
@@ -352,9 +351,7 @@ class ClusterScreen extends Component {
 
 		let addons = deployment.addons || [];
 
-		if (hasAnsibleSetup(cluster.pricing_plan)) {
-			addons = addons.filter(i => i.name === 'arc');
-		}
+		addons = addons.filter(i => i.name === 'arc');
 		if (isExternalCluster) {
 			const arcDeployment =
 				deployment &&
@@ -415,19 +412,6 @@ class ClusterScreen extends Component {
 							)}
 					</div>
 				</li>
-
-				{!hasAnsibleSetup(cluster.pricing_plan) && (
-					<li className={card}>
-						<div className="col light">
-							<h3>Dashboard</h3>
-							<p>Manage your cluster</p>
-						</div>
-
-						<div className="col">
-							{this.renderClusterEndpoint(cluster)}
-						</div>
-					</li>
-				)}
 
 				<li className={card}>
 					<div className="col light">
@@ -517,45 +501,6 @@ class ClusterScreen extends Component {
 								ElasticSearch.
 							</p>
 						</div>
-						{!hasAnsibleSetup(cluster.pricing_plan) && (
-							<div className={esContainer}>
-								<Button
-									size="large"
-									type={
-										this.state.visualization === 'grafana'
-											? 'primary'
-											: 'default'
-									}
-									css={{
-										height: 160,
-										width: '100%',
-										backgroundColor:
-											this.state.visualization ===
-											'grafana'
-												? '#eaf5ff'
-												: '#fff',
-									}}
-									onClick={() => {
-										this.setConfig(
-											'visualization',
-											'grafana',
-										);
-										this.setConfig('kibana', false);
-										this.setConfig('grafana', true);
-									}}
-								>
-									<img
-										width={120}
-										src="/static/images/clusters/grafana.png"
-										alt="Grafana"
-									/>
-								</Button>
-								<p>
-									The leading open-source tool for metrics
-									visualization.
-								</p>
-							</div>
-						)}
 					</div>
 				</li>
 

--- a/src/pages/ClusterPage/utils/index.js
+++ b/src/pages/ClusterPage/utils/index.js
@@ -77,23 +77,6 @@ export const PLAN_LABEL = {
 	[CLUSTER_PLANS.PRODUCTION_2019_3]: 'Production 3',
 };
 
-export function hasAnsibleSetup(pricingPlan) {
-	const plans = [
-		CLUSTER_PLANS.SANDBOX_2020,
-		CLUSTER_PLANS.HOBBY_2020,
-		CLUSTER_PLANS.STARTER_2020,
-		CLUSTER_PLANS.PRODUCTION_2019_1,
-		CLUSTER_PLANS.PRODUCTION_2019_2,
-		CLUSTER_PLANS.PRODUCTION_2019_3,
-		ARC_PLANS.HOSTED_ARC_BASIC,
-		ARC_PLANS.HOSTED_ARC_BASIC_V2,
-		ARC_PLANS.HOSTED_ARC_STANDARD,
-		ARC_PLANS.HOSTED_ARC_ENTERPRISE,
-	];
-
-	return plans.some(i => i === pricingPlan);
-}
-
 export function getClusters() {
 	return new Promise((resolve, reject) => {
 		fetch(`${ACC_API}/v1/clusters`, {


### PR DESCRIPTION
## What is this PR for?
Removes `hasAnsible` util as now all the clusters are now using ansible setup

## How have you tested this PR?

https://www.loom.com/share/ba77653a05ac4832aa02dea1f22e876f

## What pages does it affect

<!-- List the pages that this PR can affect. If it is global change, try to add any side effects that it could have -->
