### PR TITLE
fix: trial_end_date format for intercom data

### DIFF
--- a/src/pages/ClusterPage/ClusterPage.js
+++ b/src/pages/ClusterPage/ClusterPage.js
@@ -103,6 +103,7 @@ class ClusterPage extends Component {
 						trial_end_date: moment
 							.unix(this.props.clusterTrialEndDate)
 							.toDate(),
+						trial_end_at: this.props.clusterTrialEndDate,
 					});
 				}
 				if (!clusters.length) {

--- a/src/pages/ClusterPage/new.js
+++ b/src/pages/ClusterPage/new.js
@@ -309,6 +309,7 @@ class NewCluster extends Component {
 						trial_end_date: moment
 							.unix(this.props.clusterTrialEndDate)
 							.toDate(),
+						trial_end_at: this.props.clusterTrialEndDate,
 					});
 				}
 				const activeClusters = clusters.filter(


### PR DESCRIPTION
## What is this PR for?

* Fix the trial_end date format for intercom data. Adds a new field called `trial_end_at` with unix timestamp as the value

## How have you tested this PR?

<!-- Share the steps that you have followed to test this PR. Add loom video / gif / screenshot -->

https://www.loom.com/share/ed8ce6a6ed9a4045ae05ee2fd7759344

## What pages does it affect

<!-- List the pages that this PR can affect. If it is global change, try to add any side effects that it could have -->
