### PR TITLE
fix: cluster state getting reset

### DIFF
--- a/src/pages/ClusterPage/components/PricingSlider/index.js
+++ b/src/pages/ClusterPage/components/PricingSlider/index.js
@@ -63,7 +63,12 @@ class PricingSlider extends Component {
 		const { onChange, marks } = this.props;
 		// snap to nearest value
 		this.setState({ value: active });
-		onChange(marks[active]);
+		onChange(marks[active], active);
+	};
+
+	componentDidMount = () => {
+		const { currValue } = this.props;
+		this.onChange(currValue);
 	};
 
 	render() {
@@ -80,6 +85,7 @@ class PricingSlider extends Component {
 						defaultValue={value}
 						step={null}
 						tooltipVisible={false}
+						value={value}
 						{...sliderProps}
 					/>
 				</div>

--- a/src/pages/ClusterPage/new.js
+++ b/src/pages/ClusterPage/new.js
@@ -281,6 +281,7 @@ class NewCluster extends Component {
 			clusterVersion: esVersions[0],
 			pricing_plan: get(ansibleMachineMarks, `${provider}[0].plan`),
 			vm_size: get(ansibleMachineMarks, `${provider}[0].machine`),
+			vm_machine: 0,
 			region: '',
 			kibana: false,
 			streams: false,
@@ -337,7 +338,11 @@ class NewCluster extends Component {
 		if (prevState.provider !== provider) {
 			const [currentMachine] = Object.entries(
 				get(ansibleMachineMarks, `${prevState.provider}`),
-			).find(([, value]) => value.machine === prevState.vm_size);
+			).find(
+				item =>
+					item[0] === prevState.vm_machine.toString() &&
+					item[1].machine === prevState.vm_size,
+			);
 			// eslint-disable-next-line
 			this.setState({
 				pricing_plan: get(
@@ -349,6 +354,7 @@ class NewCluster extends Component {
 					`${provider}.${currentMachine}.machine`,
 				),
 				region: '',
+				vm_machine: prevState.vm_machine,
 			});
 		}
 	}
@@ -359,10 +365,11 @@ class NewCluster extends Component {
 		});
 	};
 
-	setPricing = plan => {
+	setPricing = (plan, machine) => {
 		this.setState({
 			vm_size: plan.machine,
 			pricing_plan: plan.plan,
+			vm_machine: machine,
 		});
 	};
 
@@ -748,6 +755,7 @@ class NewCluster extends Component {
 										isUsingClusterTrial &&
 										this.state.clusters.length < 1
 									}
+									currValue={this.state.vm_machine}
 								/>
 							</div>
 							{!isUsingClusterTrial && (


### PR DESCRIPTION
Issue Type - Bug

Description - Cluster Plan was getting set to default when the user changes the provider while creating a cluster.

This was happening because when the user changes the provider, the component was getting updated it was setting the plan and the vm-size according to the previous state vm_size and vm_size was the same for the starting three plans, so I created a vm_machine state which keeps track of the machine specs that was selected and in case the provider changes it sets the plan, vm_size & vm_machine accordingly also the value that was selected was passed to the PricingSlider to set the pricing when the component mounts.

https://www.loom.com/share/1d64f9398ce94af19b7394fa8c2bff33