### PR TITLE
fix: set the default gke location to us-central1

### DIFF
--- a/src/pages/ClusterPage/new.js
+++ b/src/pages/ClusterPage/new.js
@@ -281,7 +281,7 @@ class NewCluster extends Component {
 			clusterVersion: esVersions[0],
 			pricing_plan: get(ansibleMachineMarks, `${provider}[0].plan`),
 			vm_size: get(ansibleMachineMarks, `${provider}[0].machine`),
-			region: '',
+			region: 'us-central1',
 			kibana: false,
 			streams: false,
 			elasticsearchHQ: true,

--- a/src/pages/ClusterPage/utils/regions.js
+++ b/src/pages/ClusterPage/utils/regions.js
@@ -93,16 +93,17 @@ export const regions = {
 			flag: 'finland@3x.png',
 			continent: 'eu',
 		},
-		'us-east1': {
-			name: 'South Carolina',
-			flag: 'united-states.png',
-			continent: 'us',
-		},
 		'us-central1': {
 			name: 'Iowa',
 			flag: 'united-states.png',
 			continent: 'us',
 		},
+		'us-east1': {
+			name: 'South Carolina',
+			flag: 'united-states.png',
+			continent: 'us',
+		},
+
 		'us-east4': {
 			name: 'N. Virginia',
 			flag: 'united-states.png',


### PR DESCRIPTION
## What is this PR for?
* Update default location for gke cluster to `us-central1`
<!-- Brief description of feature / bug fix that this PR do. -->

<!--  Link to Notion card / Github issue -->

## How have you tested this PR?

<!-- Share the steps that you have followed to test this PR. Add loom video / gif / screenshot -->

## What pages does it affect

<!-- List the pages that this PR can affect. If it is global change, try to add any side effects that it could have -->
