### PR TITLE
feat: support added for rotating api credentials

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
 		"topojson-client": "^3.0.0",
 		"url-parser-lite": "^0.1.0",
 		"url-search-params": "^1.1.0",
-		"urlsafe-base64": "https://github.com/farhan687/urlsafe-base64.git"
+		"urlsafe-base64": "https://github.com/farhan687/urlsafe-base64.git",
+		"uuid": "^8.3.2"
 	}
 }

--- a/src/pages/ClusterPage/screens/ClusterScreen.js
+++ b/src/pages/ClusterPage/screens/ClusterScreen.js
@@ -22,6 +22,7 @@ import {
 	PLAN_LABEL,
 	EFFECTIVE_PRICE_BY_PLANS,
 	PRICE_BY_PLANS,
+	rotateAPICredentials,
 } from '../utils';
 
 const { Option } = Select;
@@ -327,6 +328,8 @@ class ClusterScreen extends Component {
 					<CredentialsBox
 						name={name}
 						text={`${username}:${password}`}
+						rotateAPICredentials={rotateAPICredentials}
+						clusterId={this.props.clusterId}
 					/>
 				</div>
 			);
@@ -559,7 +562,9 @@ class ClusterScreen extends Component {
 										key={`${item.id}___${item.repository_name}`}
 										value={`${item.id}___${item.repository_name}`}
 									>
-										{new Date(+item.id * 1000).toString().substring(0, 15)}
+										{new Date(+item.id * 1000)
+											.toString()
+											.substring(0, 15)}
 									</Option>
 								))}
 							</Select>

--- a/src/pages/ClusterPage/styles.js
+++ b/src/pages/ClusterPage/styles.js
@@ -446,6 +446,37 @@ const credsBox = css`
 	}
 `;
 
+const confirmationBox = css`
+	width: 250px;
+	.confirmation-header {
+		padding-bottom: 10px;
+	}
+	.icon-wrapper {
+		padding-right: 5px;
+	}
+	.icon {
+		color: #debd00;
+	}
+	.confirmation-text {
+		padding-bottom: 10px;
+	}
+	.buttons-wrapper {
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+		padding-bottom: 10px;
+	}
+	.cancel-button {
+		margin-right: 2px;
+	}
+	.confirm-button {
+		margin-left: 5px;
+	}
+	.button-text {
+		font-size: 12;
+	}
+`;
+
 const invoiceTable = css`
 	width: 100%;
 	margin: 20px 20px 30px;
@@ -533,4 +564,5 @@ export {
 	esContainer,
 	clusterButtons,
 	bannerContainer,
+	confirmationBox,
 };

--- a/src/pages/ClusterPage/utils/index.js
+++ b/src/pages/ClusterPage/utils/index.js
@@ -1,4 +1,5 @@
 import get from 'lodash/get';
+import { v4 as uuidv4 } from 'uuid';
 import { ACC_API } from '../../../constants/config';
 
 export const CLUSTER_PLANS = {
@@ -547,7 +548,7 @@ export const hasAddon = (item, source) =>
 	!!(source.addons || []).find(key => key.name === item);
 export const getAddon = (item, source) =>
 	(source.addons || []).find(key => key.name === item);
-const generateRandomString = length => {
+const generateRandomUsername = length => {
 	const chars =
 		'0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 	let result = '';
@@ -557,13 +558,8 @@ const generateRandomString = length => {
 };
 
 export const rotateAPICredentials = (type, clusterId) => {
-	const username = generateRandomString(9);
-	const password = `${generateRandomString(8)}-${generateRandomString(
-		4,
-	)}-${generateRandomString(4)}-${generateRandomString(
-		4,
-	)}-${generateRandomString(12)}`;
-
+	const username = generateRandomUsername(9);
+	const password = uuidv4();
 	let reqBody = {};
 	switch (type) {
 		case 'Elasticsearch':

--- a/yarn.lock
+++ b/yarn.lock
@@ -15727,6 +15727,11 @@ uuid@^3.0.1, uuid@^3.2.1, uuid@^3.3.2:
   resolved "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 v8-compile-cache@2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz#00f7494d2ae2b688cfe2899df6ed2c54bef91dbe"


### PR DESCRIPTION
## What is this PR for?

Added support for rotating API credentials in dashboard - clusterScreen (CredentialsBox component)
 - UI added to generate random username and password
 - Confirmation box added
 - Upon confirmation the username and password for (ES / kibana / Appbase.io) is saved in the server and according to the response received confirmation or error alert is shown to the user

Notion Link - https://www.notion.so/appbase/Add-Support-to-rotate-API-credentials-66e8ad93f0594398baf16023cdaf377c 

## What pages does it affect
 - ClusterScreen
 
 demo - 
 https://www.loom.com/share/55d7cd97fd63452d94078894ff74218f