### PR TITLE
fix: use the non LB deployment for sandbox

### DIFF
--- a/src/pages/ClusterPage/NewMyCluster.js
+++ b/src/pages/ClusterPage/NewMyCluster.js
@@ -232,6 +232,8 @@ class NewMyCluster extends Component {
 				pricing_plan: this.state.pricing_plan,
 				location: this.state.region,
 				arc_image: ARC_BYOC,
+				is_multi_zone:
+					this.state.pricing_plan === ARC_PLANS.HOSTED_ARC_BASIC_V2,
 			};
 
 			if (stripeData.token) {

--- a/src/pages/ClusterPage/new.js
+++ b/src/pages/ClusterPage/new.js
@@ -94,7 +94,7 @@ export const ansibleMachineMarks = {
 		label: PLAN_LABEL[CLUSTER_PLANS.PRODUCTION_2019_1],
 		plan: CLUSTER_PLANS.PRODUCTION_2019_1,
 		storage: 480,
-		memory: 1,
+		memory: 16,
 		nodes: 3,
 		cpu: 4,
 		cost: PRICE_BY_PLANS[CLUSTER_PLANS.PRODUCTION_2019_1],
@@ -146,7 +146,7 @@ export const ansibleMachineMarks = {
 		label: PLAN_LABEL[CLUSTER_PLANS.PRODUCTION_2021_1],
 		plan: CLUSTER_PLANS.PRODUCTION_2021_1,
 		storage: 480,
-		memory: 1,
+		memory: 16,
 		nodes: 3,
 		cpu: 4,
 		cost: PRICE_BY_PLANS[CLUSTER_PLANS.PRODUCTION_2021_1],
@@ -383,7 +383,8 @@ class NewCluster extends Component {
 					pricing_plan: this.state.pricing_plan,
 					ssh_public_key: SSH_KEY,
 					provider: this.state.provider,
-					is_multi_zone: false,
+					is_multi_zone:
+						this.state.pricing_plan === CLUSTER_PLANS.SANDBOX_2020,
 				},
 				addons: [
 					{


### PR DESCRIPTION
## What is this PR for?

For sandbox and arc basic use the normal deployment instead of LB deployment as we have exceeded the HTTPS proxies quota

## How have you tested this PR?

<!-- Share the steps that you have followed to test this PR. Add loom video / gif / screenshot -->

## What pages does it affect

<!-- List the pages that this PR can affect. If it is global change, try to add any side effects that it could have -->
