### PR TITLE
fix: remove metricbeat from restore

### DIFF
--- a/src/pages/ClusterPage/utils/index.js
+++ b/src/pages/ClusterPage/utils/index.js
@@ -177,7 +177,7 @@ export function restore(cluster, restoreFrom, snapshot_id, repository) {
 			credentials: 'include',
 			body: JSON.stringify({
 				snapshot_id,
-				indices: '-.*',
+				indices: '-.*,-metricbeat-*',
 				repository_name: repository,
 			}),
 			headers: {


### PR DESCRIPTION
## What is this PR for?

Removes metricbeat indices from restore

<!-- Brief description of feature / bug fix that this PR do. -->

<!--  Link to Notion card / Github issue -->

## How have you tested this PR?

<!-- Share the steps that you have followed to test this PR. Add loom video / gif / screenshot -->

## What pages does it affect

<!-- List the pages that this PR can affect. If it is global change, try to add any side effects that it could have -->
