### PR TITLE
fix: allow clipboard read/write access for the iframe

### DIFF
--- a/src/pages/ClusterPage/explore.js
+++ b/src/pages/ClusterPage/explore.js
@@ -167,6 +167,7 @@ export default class ExploreCluster extends Component {
 					width="100%"
 					height={`${window.innerHeight - 65}px`}
 					onLoad={this.frameLoaded}
+					allow="clipboard-read; clipboard-write"
 					data-hj-allow-iframe=""
 				/>
 			</Fragment>

--- a/src/pages/ClusterPage/explore.js
+++ b/src/pages/ClusterPage/explore.js
@@ -167,7 +167,7 @@ export default class ExploreCluster extends Component {
 					width="100%"
 					height={`${window.innerHeight - 65}px`}
 					onLoad={this.frameLoaded}
-					allow="clipboard-read; clipboard-write"
+					allow="clipboard-write"
 					data-hj-allow-iframe=""
 				/>
 			</Fragment>


### PR DESCRIPTION
## What is this PR for?
Since we load the `Explore Cluster` dashboard inside an iframe (that is cross-origin due to being on a different sub-domain), we need to allow clipboard permissions to it for enabling reading/writing from the clipboard.
<!-- Brief description of feature / bug fix that this PR do. -->

<!--  Link to Notion card / Github issue -->

## How have you tested this PR?
I've tested the solution with a main frame as a codepen domain that embeds the main dashboard. Link: https://codepen.io/sids-aquarius/pen/XWMzOwG?editors=1111

Reference: https://hellodevworld.com/misc/copying-to-clipboard-from-iframe

<!-- Share the steps that you have followed to test this PR. Add loom video / gif / screenshot -->

## What pages does it affect
Explore Cluster > Develop > Request Logs > Details view
<!-- List the pages that this PR can affect. If it is global change, try to add any side effects that it could have -->
