### PR TITLE
feat: add support for opensearch cluster creation

### DIFF
--- a/src/pages/ClusterPage/info.js
+++ b/src/pages/ClusterPage/info.js
@@ -494,6 +494,7 @@ class ClusterInfo extends Component {
 			deployment &&
 			deployment.addons &&
 			deployment.addons.find(addon => addon.name === 'arc');
+
 		return (
 			<Fragment>
 				<FullHeader

--- a/src/pages/ClusterPage/new.js
+++ b/src/pages/ClusterPage/new.js
@@ -33,7 +33,7 @@ const SSH_KEY =
 
 const esVersions = ['7.10.2', '7.9.3', '7.8.1', '7.8.0', '7.7.1'];
 
-const odfeVersions = ['1.13.2', '1.12.0', '1.11.0', '1.9.0', '1.8.0'];
+const openSearchVersions = ['1.0.0'];
 
 export const V7_ARC = '7.46.0-cluster';
 export const V6_ARC = '7.46.0-cluster';
@@ -374,7 +374,8 @@ class NewCluster extends Component {
 						item => this.state[item],
 					),
 					restore_from: this.state.restore_from,
-					odfe: parseInt(this.state.clusterVersion, 10) < 5,
+					odfe: false,
+					opensearch: this.state.esFlavor === 'opensearch',
 				},
 				cluster: {
 					name: this.state.clusterName,
@@ -407,12 +408,16 @@ class NewCluster extends Component {
 				body.kibana = {
 					create_node: false,
 					version: this.state.clusterVersion,
-					odfe: parseInt(this.state.clusterVersion, 10) < 5,
+					odfe: false,
 				};
 			}
 
 			if (this.state.visualization === 'grafana') {
 				body.grafana = true;
+			}
+
+			if (this.state.visualization === 'opensearch') {
+				body.elasticsearch.opensearch_dashboard = true;
 			}
 
 			if (stripeData.token) {
@@ -601,7 +606,9 @@ class NewCluster extends Component {
 		const isInvalid = !this.validateClusterName();
 		if (isLoading) return <Loader />;
 		const versions =
-			this.state.esFlavor === 'odfe' ? odfeVersions : esVersions;
+			this.state.esFlavor === 'opensearch'
+				? openSearchVersions
+				: esVersions;
 		const defaultVersion = this.state.clusterVersion;
 
 		const activeClusters = clusters.filter(
@@ -867,7 +874,8 @@ class NewCluster extends Component {
 										<Button
 											size="large"
 											type={
-												this.state.esFlavor === 'odfe'
+												this.state.esFlavor ===
+												'opensearch'
 													? 'primary'
 													: 'default'
 											}
@@ -875,29 +883,29 @@ class NewCluster extends Component {
 												height: 160,
 												backgroundColor:
 													this.state.esFlavor ===
-													'odfe'
+													'opensearch'
 														? '#eaf5ff'
 														: '#fff',
 											}}
 											onClick={() => {
 												this.setConfig(
 													'esFlavor',
-													'odfe',
+													'opensearch',
 												);
 												this.setConfig(
 													'clusterVersion',
-													odfeVersions[0],
+													openSearchVersions[0],
 												);
 											}}
 										>
 											<img
 												width="150"
-												src="/static/images/clusters/odfe.svg"
-												alt="ODFE"
+												src="https://opensearch.org/assets/brand/SVG/Logo/opensearch_logo_default.svg"
+												alt="Open Search"
 											/>
 										</Button>
 										<p>
-											Open Distro by Amazon, includes
+											OpenSearch by Amazon, includes
 											additional security enhancements.
 										</p>
 									</div>
@@ -989,7 +997,9 @@ class NewCluster extends Component {
 											size="large"
 											type={
 												this.state.visualization ===
-												'kibana'
+													'kibana' ||
+												this.state.visualization ===
+													'opensearch'
 													? 'primary'
 													: 'default'
 											}
@@ -998,26 +1008,35 @@ class NewCluster extends Component {
 												width: '100%',
 												backgroundColor:
 													this.state.visualization ===
-													'kibana'
+														'kibana' ||
+													this.state.visualization ===
+														'opensearch'
 														? '#eaf5ff'
 														: '#fff',
 											}}
 											onClick={() => {
 												this.setConfig(
 													'visualization',
-													'kibana',
+													this.state.esFlavor ===
+														'opensearch'
+														? 'opensearch'
+														: 'kibana',
 												);
 											}}
 										>
 											<img
 												width={150}
-												src="https://static-www.elastic.co/v3/assets/bltefdd0b53724fa2ce/blt8781708f8f37ed16/5c11ec2edf09df047814db23/logo-elastic-kibana-lt.svg"
-												alt="Kibana"
+												src={
+													this.state.esFlavor ===
+													'opensearch'
+														? `https://opensearch.org/assets/brand/SVG/Logo/opensearch_logo_default.svg`
+														: `https://static-www.elastic.co/v3/assets/bltefdd0b53724fa2ce/blt8781708f8f37ed16/5c11ec2edf09df047814db23/logo-elastic-kibana-lt.svg`
+												}
+												alt="visualization"
 											/>
 										</Button>
 										<p>
-											The default visualization dashboard
-											for ElasticSearch.
+											The default visualization dashboard.
 										</p>
 									</div>
 								</div>

--- a/src/pages/ClusterPage/screens/ClusterScreen.js
+++ b/src/pages/ClusterPage/screens/ClusterScreen.js
@@ -288,7 +288,8 @@ class ClusterScreen extends Component {
 				'://',
 			);
 			const copyURL =
-				source.name === 'kibana'
+				source.name === 'kibana' ||
+				source.name === 'OpenSearch Dashboard'
 					? `${protocol}://${url}`
 					: `${protocol}://${username}:${password}@${url}`.replace(
 							/\/$/,
@@ -352,7 +353,8 @@ class ClusterScreen extends Component {
 
 	render() {
 		const { cluster, deployment, isStripeCheckoutOpen } = this.state;
-
+		const isOpenSearchFlavour =
+			Number(this.state.cluster.es_version.split('.')[0]) < 7;
 		const {
 			clusterId,
 			isPaid,
@@ -511,7 +513,11 @@ class ClusterScreen extends Component {
 							>
 								<img
 									width={150}
-									src="https://static-www.elastic.co/v3/assets/bltefdd0b53724fa2ce/blt8781708f8f37ed16/5c11ec2edf09df047814db23/logo-elastic-kibana-lt.svg"
+									src={
+										isOpenSearchFlavour
+											? `https://opensearch.org/assets/brand/SVG/Logo/opensearch_logo_default.svg`
+											: `https://static-www.elastic.co/v3/assets/bltefdd0b53724fa2ce/blt8781708f8f37ed16/5c11ec2edf09df047814db23/logo-elastic-kibana-lt.svg`
+									}
 									alt="Kibana"
 								/>
 							</Button>

--- a/src/pages/ClusterPage/screens/ClusterScreen.js
+++ b/src/pages/ClusterPage/screens/ClusterScreen.js
@@ -275,7 +275,7 @@ class ClusterScreen extends Component {
 		this.props.handleToken(data);
 	};
 
-	renderClusterEndpoint = source => {
+	renderClusterEndpoint = (source, isOpenSearchFlavour) => {
 		if (
 			Object.keys(source).length &&
 			source.name &&
@@ -301,7 +301,7 @@ class ClusterScreen extends Component {
 				name = 'Appbase.io';
 			}
 			if (name === 'elasticsearch') {
-				name = 'Elasticsearch';
+				name = isOpenSearchFlavour ? 'OpenSearch' : 'Elasticsearch';
 			}
 			return (
 				<div key={name} className={clusterEndpoint}>
@@ -421,7 +421,11 @@ class ClusterScreen extends Component {
 			<Fragment>
 				<li className={card}>
 					<div className="col light">
-						<h3>Elasticsearch</h3>
+						<h3>
+							{isOpenSearchFlavour
+								? 'OpenSearch'
+								: 'Elasticsearch'}
+						</h3>
 						<p>Live cluster endpoint</p>
 					</div>
 
@@ -429,7 +433,10 @@ class ClusterScreen extends Component {
 						{Object.keys(deployment)
 							.filter(item => item !== 'addons')
 							.map(key =>
-								this.renderClusterEndpoint(deployment[key]),
+								this.renderClusterEndpoint(
+									deployment[key],
+									isOpenSearchFlavour,
+								),
 							)}
 					</div>
 				</li>


### PR DESCRIPTION
## What is this PR for?
Add support for OpenSearch

- [x] Allow creating opensearch cluster
- [x] Allow scaling up opensearch cluster
- [x] Allow scaling down opensearch cluster
- [x] Allow user to enable / disable opensearch dashboard

## How have you tested this PR?
<img width="1326" alt="Screenshot 2021-08-03 at 1 23 05 PM" src="https://user-images.githubusercontent.com/6964334/127978786-82257df4-470a-4bbd-b215-3e2da5be561c.png">

- [x] Create gcloud cluster
- [x] Create AWS cluster
- [x] Scale up cluster
- [x] Scale down cluster
- [x] Create a cluster with opensearch dashboard
- [x] Create a cluster without opensearch dashboard
- [x] Enable / Disable open search dasbhoard

## What pages does it affect
* Cluster creation
* Cluster details
