### PR TITLE
fix(cluster detail): restrict viewer role access

### DIFF
--- a/src/pages/ClusterPage/components/CredentialsBox/index.js
+++ b/src/pages/ClusterPage/components/CredentialsBox/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Icon, message, Popover, Button } from 'antd';
-import { string, func } from 'prop-types';
+import { string, func, bool } from 'prop-types';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { credsBox, confirmationBox } from '../../styles';
 
@@ -12,6 +12,7 @@ export default class CredentialsBox extends Component {
 			hidden: props.hidden || true,
 			confirmationBoxVisible: false,
 			displayText: undefined,
+			showRotateAPICredentials: props.showRotateAPICredentials || false,
 		};
 	}
 
@@ -53,6 +54,7 @@ export default class CredentialsBox extends Component {
 	};
 
 	renderConfirmationBox = (type, rotateAPICredentials, clusterId) => {
+		const { showRotateAPICredentials } = this.state;
 		return (
 			<Popover
 				content={
@@ -68,8 +70,11 @@ export default class CredentialsBox extends Component {
 							Warning
 						</div>
 						<div className="confirmation-text">
-							Rotating API credentials will invalidate the current
-							API credential. Do you still want to proceed?
+							{showRotateAPICredentials &&
+								`Rotating API credentials will invalidate the current
+							API credential. Do you still want to proceed?`}
+							{!showRotateAPICredentials &&
+								`Your role is of type viewer. Only an admin role can rotate the API credentials.`}
 						</div>
 						<div className="buttons-wrapper">
 							<div>
@@ -83,22 +88,26 @@ export default class CredentialsBox extends Component {
 									<span className="button-text">Cancel</span>
 								</Button>
 							</div>
-							<div>
-								<Button
-									type="primary"
-									size="small"
-									onClick={() =>
-										this.updateAPICredentials(
-											type,
-											clusterId,
-											rotateAPICredentials,
-										)
-									}
-									className="confirm-button"
-								>
-									<span className="button-text">Confirm</span>
-								</Button>
-							</div>
+							{showRotateAPICredentials && (
+								<div>
+									<Button
+										type="primary"
+										size="small"
+										onClick={() =>
+											this.updateAPICredentials(
+												type,
+												clusterId,
+												rotateAPICredentials,
+											)
+										}
+										className="confirm-button"
+									>
+										<span className="button-text">
+											Confirm
+										</span>
+									</Button>
+								</div>
+							)}
 						</div>
 					</div>
 				}
@@ -187,4 +196,5 @@ CredentialsBox.propTypes = {
 	text: string.isRequired,
 	name: string.isRequired,
 	rotateAPICredentials: func.isRequired,
+	showRotateAPICredentials: bool,
 };

--- a/src/pages/ClusterPage/info.js
+++ b/src/pages/ClusterPage/info.js
@@ -812,7 +812,8 @@ class ClusterInfo extends Component {
 										this.state.arcVersion ||
 											arcDeployment.image,
 										this.state.cluster.recipe,
-									) && (
+									) &&
+									!isViewer && (
 										<Alert
 											message="A new appbase.io version is available!"
 											description={

--- a/src/pages/ClusterPage/screens/ClusterScreen.js
+++ b/src/pages/ClusterPage/screens/ClusterScreen.js
@@ -297,6 +297,8 @@ class ClusterScreen extends Component {
 							'',
 					  );
 			let { name } = source;
+			const { cluster } = this.state;
+			const isViewer = cluster.user_role === 'viewer';
 
 			if (name === 'arc') {
 				name = 'Appbase.io';
@@ -332,6 +334,7 @@ class ClusterScreen extends Component {
 						text={`${username}:${password}`}
 						rotateAPICredentials={rotateAPICredentials}
 						clusterId={this.props.clusterId}
+						showRotateAPICredentials={!isViewer}
 					/>
 				</div>
 			);
@@ -537,65 +540,69 @@ class ClusterScreen extends Component {
 					</div>
 				</li>
 
-				<li className={card}>
-					<div className="col light">
-						<h3>Restore From Snapshot</h3>
-						<p>Select cluster & snapshots</p>
-					</div>
+				{isViewer || (
+					<li className={card}>
+						<div className="col light">
+							<h3>Restore From Snapshot</h3>
+							<p>Select cluster & snapshots</p>
+						</div>
 
-					<div className="col">
-						<Select
-							css={{
-								width: '100%',
-								maxWidth: 400,
-							}}
-							placeholder="Select a cluster"
-							onChange={this.handleCluster}
-						>
-							{this.state.clusters
-								.filter(i => i.recipe === 'default')
-								.map(item => (
-									<Option key={item.id}>{item.name}</Option>
-								))}
-						</Select>
-						{this.state.isSnapshotsLoading && (
-							<p>Snapshots Loading</p>
-						)}
-						{this.state.snapshots.length > 0 && (
+						<div className="col">
 							<Select
 								css={{
 									width: '100%',
 									maxWidth: 400,
-									margin: '20px 0',
 								}}
-								placeholder="Select a snapshot"
-								onChange={this.handleSnapshot}
+								placeholder="Select a cluster"
+								onChange={this.handleCluster}
 							>
-								{this.state.snapshots.map(item => (
-									<Option
-										key={`${item.id}___${item.repository_name}`}
-										value={`${item.id}___${item.repository_name}`}
-									>
-										{new Date(+item.id * 1000)
-											.toString()
-											.substring(0, 15)}
-									</Option>
-								))}
+								{this.state.clusters
+									.filter(i => i.recipe === 'default')
+									.map(item => (
+										<Option key={item.id}>
+											{item.name}
+										</Option>
+									))}
 							</Select>
-						)}
+							{this.state.isSnapshotsLoading && (
+								<p>Snapshots Loading</p>
+							)}
+							{this.state.snapshots.length > 0 && (
+								<Select
+									css={{
+										width: '100%',
+										maxWidth: 400,
+										margin: '20px 0',
+									}}
+									placeholder="Select a snapshot"
+									onChange={this.handleSnapshot}
+								>
+									{this.state.snapshots.map(item => (
+										<Option
+											key={`${item.id}___${item.repository_name}`}
+											value={`${item.id}___${item.repository_name}`}
+										>
+											{new Date(+item.id * 1000)
+												.toString()
+												.substring(0, 15)}
+										</Option>
+									))}
+								</Select>
+							)}
 
-						{this.state.restore_from && this.state.snapshot_id && (
-							<Button
-								style={{ marginLeft: 8 }}
-								type="primary"
-								loading={this.state.isRestoring}
-								onClick={this.restoreCluster}
-							>
-								Restore
-							</Button>
-						)}
-					</div>
-				</li>
+							{this.state.restore_from && this.state.snapshot_id && (
+								<Button
+									style={{ marginLeft: 8 }}
+									type="primary"
+									loading={this.state.isRestoring}
+									onClick={this.restoreCluster}
+								>
+									Restore
+								</Button>
+							)}
+						</div>
+					</li>
+				)}
 				{isViewer || (
 					<div className={clusterButtons}>
 						<Button


### PR DESCRIPTION
## What is this PR for?

<!-- Brief description of feature / bug fix that this PR do. -->

<!--  Link to Notion card / Github issue -->
don't allow the following actions for a viewer role:
- rotation of API credentials
- updating a cluster version
- restoring a snapshot

## How have you tested this PR?

- A viewer role could see the following prior to this PR:

![](https://i.imgur.com/4YWnBoJ.png)

- A viewer role can now see the following:

![](https://i.imgur.com/q4lRwcX.png)

They will also see a warning popover about limited role to rotate the API credentials

![](https://i.imgur.com/vHuSqs2.png)

<!-- Share the steps that you have followed to test this PR. Add loom video / gif / screenshot -->

## What pages does it affect

<!-- List the pages that this PR can affect. If it is global change, try to add any side effects that it could have -->
