### PR TITLE
chore: update es, os, reactivesearch-api release versions

### DIFF
--- a/src/pages/ClusterPage/new.js
+++ b/src/pages/ClusterPage/new.js
@@ -37,13 +37,13 @@ const { TabPane } = Tabs;
 const SSH_KEY =
 	'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCVqOPpNuX53J+uIpP0KssFRZToMV2Zy/peG3wYHvWZkDvlxLFqGTikH8MQagt01Slmn+mNfHpg6dm5NiKfmMObm5LbcJ62Nk9AtHF3BPP42WyQ3QiGZCjJOX0fVsyv3w3eB+Eq+F+9aH/uajdI+wWRviYB+ljhprZbNZyockc6V33WLeY+EeRQW0Cp9xHGQUKwJa7Ch8/lRkNi9QE6n5W/T6nRuOvu2+ThhjiDFdu2suq3V4GMlEBBS6zByT9Ct5ryJgkVJh6d/pbocVWw99mYyVm9MNp2RD9w8R2qytRO8cWvTO/KvsAZPXj6nJtB9LaUtHDzxe9o4AVXxzeuMTzx siddharth@appbase.io';
 
-const esVersions = ['7.15.2'];
+const esVersions = ['7.16.2'];
 
-const openSearchVersions = ['1.1.0'];
+const openSearchVersions = ['1.2.3'];
 
-export const V7_ARC = '7.54.0-cluster';
-export const V6_ARC = '7.54.0-cluster';
-export const ARC_BYOC = '7.54.0-byoc';
+export const V7_ARC = '7.54.1-cluster';
+export const V6_ARC = '7.54.1-cluster';
+export const ARC_BYOC = '7.54.1-byoc';
 export const V5_ARC = 'v5-0.0.1';
 
 export const arcVersions = {


### PR DESCRIPTION
## What is this PR for?

<!-- Brief description of feature / bug fix that this PR do. -->

<!--  Link to Notion card / Github issue -->
Updates versions for ES, OS, and ReactiveSearch API server

## How have you tested this PR?

<!-- Share the steps that you have followed to test this PR. Add loom video / gif / screenshot -->
Update: There is an issue with OS 1.2.3 that's not a showstopper (cluster_id isn't set and OSD deployment has an issue), we can make this release.

## What pages does it affect

<!-- List the pages that this PR can affect. If it is global change, try to add any side effects that it could have -->
