### PR TITLE
feat: add cus_id in arc-dashboard redirect URL

### DIFF
--- a/src/components/ClusterExploreRedirect/index.js
+++ b/src/components/ClusterExploreRedirect/index.js
@@ -3,13 +3,16 @@ import get from 'lodash/get';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { Button } from 'antd';
+import { connect } from 'react-redux';
 
 const ClusterExploreRedirect = ({
 	urlParams,
 	arc,
 	clusterName,
 	customComponent,
+	cus_id,
 }) => {
+	console.log('cus_id', cus_id);
 	const exploreClusterInNewTab = () => {
 		let mainURL = 'http://dash.appbase.io';
 		let arcParams = '';
@@ -36,11 +39,13 @@ const ClusterExploreRedirect = ({
 		}
 
 		const { username, password, url: arcURL } = arc;
-		const url = `${mainURL}/?url=${arcURL.slice(
+		let url = `${mainURL}/?url=${arcURL.slice(
 			0,
 			-1,
 		)}&username=${username}&password=${password}&cluster=${clusterName}${arcParams}`;
-
+		if (cus_id) {
+			url += `&cus_id=${cus_id}`;
+		}
 		if (urlParams['auto-navigate'] === true) {
 			window.open(url, '_blank');
 		}
@@ -73,5 +78,10 @@ ClusterExploreRedirect.propTypes = {
 	arc: PropTypes.object.isRequired,
 	clusterName: PropTypes.string.isRequired,
 	customComponent: PropTypes.any,
+	cus_id: PropTypes.string,
 };
-export default ClusterExploreRedirect;
+
+const mapStateToProps = state => ({
+	cus_id: get(state, 'user.data.cus_id'),
+});
+export default connect(mapStateToProps)(ClusterExploreRedirect);

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,3 @@
-import get from 'lodash/get';
 import { ACC_API } from '../constants/config';
 
 export async function getUser() {


### PR DESCRIPTION
**PR Type** `Feature`

**Description** The PR appends a `cus_id` query param in the arc-dashboard redirect URL.

[📔  Notion](https://www.notion.so/appbase/Billing-PR-redirection-support-245c7e8f0c9a4a2bb9a75f2ab518e05d)

https://www.loom.com/share/0f50325142b0428582dd8d35f9aca39a

**Dependent PR(s)** https://github.com/appbaseio-confidential/arc-dashboard/pull/473