### PR TITLE
chore: adds reactivesearch-api 8.3.0 release

### DIFF
--- a/src/pages/ClusterPage/new.js
+++ b/src/pages/ClusterPage/new.js
@@ -55,9 +55,9 @@ const openSearchVersions = ['2.0.0'];
 
 let interval;
 
-export const V7_ARC = '8.2.0-cluster';
-export const V6_ARC = '8.2.0-cluster';
-export const ARC_BYOC = '8.2.0-byoc';
+export const V7_ARC = '8.3.0-cluster';
+export const V6_ARC = '8.3.0-cluster';
+export const ARC_BYOC = '8.3.0-byoc';
 export const V5_ARC = 'v5-0.0.1';
 
 export const arcVersions = {


### PR DESCRIPTION
## What is this PR for?

This PR adds support for reactivesearch-api 8.3.0 release.

## How have you tested this PR?

<!-- Share the steps that you have followed to test this PR. Add loom video / gif / screenshot -->
- [ ] Create a cloud cluster
- [ ] Create a BYE cluster

## What pages does it affect

New cluster creation page
<!-- List the pages that this PR can affect. If it is global change, try to add any side effects that it could have -->
