### PR TITLE
chore: update version

### DIFF
--- a/src/components/ClusterExploreRedirect/index.js
+++ b/src/components/ClusterExploreRedirect/index.js
@@ -12,9 +12,8 @@ const ClusterExploreRedirect = ({
 	customComponent,
 	cus_id,
 }) => {
-	console.log('cus_id', cus_id);
 	const exploreClusterInNewTab = () => {
-		let mainURL = 'http://dash.appbase.io';
+		let mainURL = 'https://dash.reactivesearch.io';
 		let arcParams = '';
 
 		if (urlParams) {

--- a/src/pages/ClusterPage/new.js
+++ b/src/pages/ClusterPage/new.js
@@ -49,15 +49,15 @@ const { TabPane } = Tabs;
 const SSH_KEY =
 	'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCVqOPpNuX53J+uIpP0KssFRZToMV2Zy/peG3wYHvWZkDvlxLFqGTikH8MQagt01Slmn+mNfHpg6dm5NiKfmMObm5LbcJ62Nk9AtHF3BPP42WyQ3QiGZCjJOX0fVsyv3w3eB+Eq+F+9aH/uajdI+wWRviYB+ljhprZbNZyockc6V33WLeY+EeRQW0Cp9xHGQUKwJa7Ch8/lRkNi9QE6n5W/T6nRuOvu2+ThhjiDFdu2suq3V4GMlEBBS6zByT9Ct5ryJgkVJh6d/pbocVWw99mYyVm9MNp2RD9w8R2qytRO8cWvTO/KvsAZPXj6nJtB9LaUtHDzxe9o4AVXxzeuMTzx siddharth@appbase.io';
 
-const esVersions = ['8.4.1', '7.17.5'];
+const esVersions = ['8.5.0', '7.17.7'];
 
-const openSearchVersions = ['2.2.1'];
+const openSearchVersions = ['2.3.0'];
 
 let interval;
 
-export const V7_ARC = '8.6.1-cluster';
-export const V6_ARC = '8.6.1-cluster';
-export const ARC_BYOC = '8.6.1-byoc';
+export const V7_ARC = '8.8.0-cluster';
+export const V6_ARC = '8.8.0-cluster';
+export const ARC_BYOC = '8.8.0-byoc';
 export const V5_ARC = 'v5-0.0.1';
 
 export const arcVersions = {


### PR DESCRIPTION
## What is this PR for?

Upgrade latest Elasticsearch (8.5.0), OpenSearch (2.3.0) and ReactiveSearch API server (8.8.0) versions

## How have you tested this PR?

- [x] Create ES cluster
- [x] Create OS cluster
- [x] Create RS API server cluster

## What pages does it affect

* New cluster
