### PR TITLE
chore: add new reactivesearch version

### DIFF
--- a/src/pages/ClusterPage/new.js
+++ b/src/pages/ClusterPage/new.js
@@ -55,9 +55,9 @@ const openSearchVersions = ['2.3.0'];
 
 let interval;
 
-export const V7_ARC = '8.8.0-cluster';
-export const V6_ARC = '8.8.0-cluster';
-export const ARC_BYOC = '8.8.0-byoc';
+export const V7_ARC = '8.8.1-cluster';
+export const V6_ARC = '8.8.1-cluster';
+export const ARC_BYOC = '8.8.1-byoc';
 export const V5_ARC = 'v5-0.0.1';
 
 export const arcVersions = {


### PR DESCRIPTION
## What is this PR for?

Adds a new version of ReactiveSearch API server: `8.8.1`

<!-- Brief description of feature / bug fix that this PR do. -->

<!--  Link to Notion card / Github issue -->

## How have you tested this PR?

By creating a cluster

<!-- Share the steps that you have followed to test this PR. Add loom video / gif / screenshot -->

## What pages does it affect

<!-- List the pages that this PR can affect. If it is global change, try to add any side effects that it could have -->

New cluster and cluster details