### PR TITLE
Upgrades ReactiveSearch to 8.9.0

### DIFF
--- a/src/pages/ClusterPage/new.js
+++ b/src/pages/ClusterPage/new.js
@@ -49,9 +49,9 @@ const openSearchVersions = ['2.3.0'];
 
 let interval;
 
-export const V7_ARC = '8.8.1-cluster';
-export const V6_ARC = '8.8.1-cluster';
-export const ARC_BYOC = '8.8.1-byoc';
+export const V7_ARC = '8.9.0-cluster';
+export const V6_ARC = '8.9.0-cluster';
+export const ARC_BYOC = '8.9.0-byoc';
 export const V5_ARC = 'v5-0.0.1';
 
 export const arcVersions = {


### PR DESCRIPTION
## What is this PR for?

This PR updates the ReactiveSearch cluster's release version to 8.9.0

## How have you tested this PR?

- [x] Upgrading an existing cluster
- [x] Creating a new cluster

## What pages does it affect

- New cluster page
- Existing cluster's details page