### PR TITLE
Es upgrade

### DIFF
--- a/src/pages/ClusterPage/info.js
+++ b/src/pages/ClusterPage/info.js
@@ -404,9 +404,7 @@ class ClusterInfo extends Component {
 
 			const url = `${ACC_API}/v2/_es_upgrade/${id}`;
 			const body = {
-				cluster_id: id,
 				target_version: checkIfESUpdateIsAvailable(es_version),
-				message: '',
 			};
 
 			const response = await fetch(url, {

--- a/src/pages/ClusterPage/info.js
+++ b/src/pages/ClusterPage/info.js
@@ -1005,67 +1005,66 @@ class ClusterInfo extends Component {
 											}}
 										/>
 									)}
-								{console.log('this.state.cluster', this.state)}
-								{((this.state.cluster.es_version &&
+								{this.state.cluster.es_version &&
 									checkIfESUpdateIsAvailable(
 										this.state.cluster.es_version,
 									) &&
 									!isViewer &&
 									!isSLSCluster &&
-									!isExternalCluster) ||
-									true) && (
-									<Alert
-										message={`A new ${
-											this.state.cluster.elasticsearch_url
-												? 'Elasticsearch'
-												: 'Opensearch'
-										} version is available!`}
-										description={
-											<div
-												style={{
-													display: 'flex',
-													justifyContent:
-														'space-between',
-													alignItems: 'center',
-												}}
-											>
-												<div>
-													A new version{' '}
-													{checkIfESUpdateIsAvailable(
-														this.state.cluster
-															.es_version,
-													)}{' '}
-													is available now.
-													You&apos;re currently on{' '}
-													{
-														this.state.cluster
-															.es_version
-													}
-													. See what&apos;s new in{' '}
-													<a href="https://github.com/appbaseio/reactivesearch-api/releases">
-														this release
-													</a>
-													.
-												</div>
-												<Button
-													type="primary"
-													ghost
-													onClick={
-														this.handleESUpgrade
-													}
+									!isExternalCluster && (
+										<Alert
+											message={`A new ${
+												this.state.cluster
+													.elasticsearch_url
+													? 'Elasticsearch'
+													: 'Opensearch'
+											} version is available!`}
+											description={
+												<div
+													style={{
+														display: 'flex',
+														justifyContent:
+															'space-between',
+														alignItems: 'center',
+													}}
 												>
-													{' '}
-													Update Now
-												</Button>
-											</div>
-										}
-										type="info"
-										showIcon
-										style={{
-											marginBottom: 25,
-										}}
-									/>
-								)}
+													<div>
+														A new version{' '}
+														{checkIfESUpdateIsAvailable(
+															this.state.cluster
+																.es_version,
+														)}{' '}
+														is available now.
+														You&apos;re currently on{' '}
+														{
+															this.state.cluster
+																.es_version
+														}
+														. See what&apos;s new in{' '}
+														<a href="https://github.com/appbaseio/reactivesearch-api/releases">
+															this release
+														</a>
+														.
+													</div>
+													<Button
+														type="primary"
+														ghost
+														onClick={
+															this.handleESUpgrade
+														}
+													>
+														{' '}
+														Update Now
+													</Button>
+												</div>
+											}
+											type="info"
+											showIcon
+											style={{
+												marginBottom: 25,
+											}}
+										/>
+									)}
 
 								<div
 									css={{

--- a/src/pages/ClusterPage/info.js
+++ b/src/pages/ClusterPage/info.js
@@ -57,7 +57,7 @@ const checkIfUpdateIsAvailable = (version, recipe) => {
 	return version && version !== V7_ARC.split('-')[0];
 };
 
-const NEW_ES_VERSIONS = { '7': '7.17.8', '8': '8.6.0', '2': '2.4.1' };
+const NEW_ES_VERSIONS = { '7': '7.17.8', '8': '8.6.0', '2': '2.5.0' };
 
 const checkIfESUpdateIsAvailable = version => {
 	const [majorVersion, minorVersion] = version.split('.');


### PR DESCRIPTION
**PR Type** `feat`

**Description** The PR adds a banner to upgrade the minor versions of the backends(elasticsearch or opensearch).

[📔  Notion](https://www.notion.so/reactivesearch/ES-Upgrade-FE-ae36ca78b7de499f8de1539fe3810e08)

https://www.loom.com/share/759b1baf08564211af7b9b89bab46f5c