### PR TITLE
fix: remove duplicate deploy logs

### DIFF
--- a/src/pages/ClusterPage/info.js
+++ b/src/pages/ClusterPage/info.js
@@ -827,14 +827,7 @@ class ClusterInfo extends Component {
 									statusFetchCount={
 										this.state.statusFetchCount
 									}
-								/>
-								{this.state.cluster.status ===
-								'deployments in progress' ? (
-									<DeployLogs
-										clusterId={this.state.cluster.id}
-										showClusterDetails={false}
-									/>
-								) : null}
+								/>								
 								{this.state.arc ? (
 									<li
 										className={card}


### PR DESCRIPTION
**PR Type** `fix` 🐞 

**Description** The PR fixes duplicate components showing up for in-progress cluster deployment.

[📔 Notion](https://www.notion.so/reactivesearch/Duplicate-Deploy-logs-for-cluster-deployment-dc3b736b5f5144c6978c3749d8fd5cd0)