### PR TITLE
Add a billing route in the main dashboard 

### DIFF
--- a/src/pages/ProfilePage/Billing.js
+++ b/src/pages/ProfilePage/Billing.js
@@ -1,0 +1,48 @@
+import { SelectOutlined } from '@ant-design/icons';
+import { Button, Card } from 'antd';
+import Paragraph from 'antd/es/typography/Paragraph';
+import { string } from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+
+const Billing = ({ userEmail }) => {
+	const getBillingPortalURL = () => {
+		let URL = 'https://billing.stripe.com/p/login/fZeeXudKqdV83rGdQQ';
+
+		if (userEmail) {
+			URL += `?prefilled_email=${encodeURIComponent(userEmail)}`;
+		}
+
+		return URL;
+	};
+	return (
+		<Card title="Manage Billing">
+			<Paragraph>
+				ReactiveSearch partners with Stripe for customer billing. You
+				can update payment method, view subscriptions, and get past
+				invoices by opening the billing portal link below.
+			</Paragraph>
+			<Button
+				type="primary"
+				href={getBillingPortalURL()}
+				target="_blank"
+				icon={<SelectOutlined rotate={90} />}
+			>
+				Billing Settings and Invoice History
+			</Button>
+		</Card>
+	);
+};
+
+Billing.propTypes = {
+	userEmail: string,
+};
+Billing.defaultProps = {
+	userEmail: '',
+};
+
+const mapStateToProps = state => ({
+	userEmail: state.user?.data?.email ?? '',
+});
+
+export default connect(mapStateToProps)(Billing);

--- a/src/pages/ProfilePage/index.js
+++ b/src/pages/ProfilePage/index.js
@@ -13,6 +13,7 @@ import FullHeader from '../../components/FullHeader';
 import Flex from '../../batteries/components/shared/Flex';
 
 import { mediaKey, breakpoints } from '../../utils/media';
+import Billing from './Billing';
 
 const { Item } = Menu;
 
@@ -61,6 +62,7 @@ class Profile extends Component<Props> {
 			>
 				<Item key="account">Account</Item>
 				<Item key="email">Email</Item>
+				<Item key="billing">Billing</Item>
 				<Item key="credentials">Credentials</Item>
 				<Item key="close">Close Account</Item>
 			</Menu>
@@ -120,6 +122,10 @@ class Profile extends Component<Props> {
 								component={Account}
 							/>
 							<Route path="/profile/email" component={Email} />
+							<Route
+								path="/profile/billing"
+								component={Billing}
+							/>
 							<Route
 								path="/profile/credentials"
 								component={Credentials}


### PR DESCRIPTION
**PR Type** `feat`

**Description** The PR adds a billing route in the profile section.

[📔 Notion ](https://www.notion.so/reactivesearch/Integrate-billing-page-in-main-dashboard-3414f0c0136545118e9feb3a5e374709)

https://www.loom.com/share/1f8914de16824698902117b7105bcbc7