### PR TITLE
chore(release): add new search engine versions

### DIFF
--- a/src/pages/ClusterPage/new.js
+++ b/src/pages/ClusterPage/new.js
@@ -43,9 +43,9 @@ const { TabPane } = Tabs;
 const SSH_KEY =
 	'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCVqOPpNuX53J+uIpP0KssFRZToMV2Zy/peG3wYHvWZkDvlxLFqGTikH8MQagt01Slmn+mNfHpg6dm5NiKfmMObm5LbcJ62Nk9AtHF3BPP42WyQ3QiGZCjJOX0fVsyv3w3eB+Eq+F+9aH/uajdI+wWRviYB+ljhprZbNZyockc6V33WLeY+EeRQW0Cp9xHGQUKwJa7Ch8/lRkNi9QE6n5W/T6nRuOvu2+ThhjiDFdu2suq3V4GMlEBBS6zByT9Ct5ryJgkVJh6d/pbocVWw99mYyVm9MNp2RD9w8R2qytRO8cWvTO/KvsAZPXj6nJtB9LaUtHDzxe9o4AVXxzeuMTzx siddharth@appbase.io';
 
-const esVersions = ['8.6.1', '7.17.8'];
+const esVersions = ['8.6.2', '7.17.8'];
 
-const openSearchVersions = ['2.5.0'];
+const openSearchVersions = ['2.6.0'];
 
 let interval;
 

--- a/src/pages/ClusterPage/new.js
+++ b/src/pages/ClusterPage/new.js
@@ -49,11 +49,11 @@ const openSearchVersions = ['2.6.0'];
 
 let interval;
 
-export const V7_ARC = '8.9.3-cluster';
-export const V6_ARC = '8.9.3-cluster';
-export const ARC_BYOC = '8.9.3-byoc';
+export const V7_ARC = '8.10.1-cluster';
+export const V6_ARC = '8.10.1-cluster';
+export const ARC_BYOC = '8.10.1-byoc';
 export const V5_ARC = 'v5-0.0.1';
-export const REACTIVESEARCH_BYOC = '8.4.0-byoc';
+export const REACTIVESEARCH_BYOC = '8.10.1-byoc';
 
 export const arcVersions = {
 	7: V7_ARC,


### PR DESCRIPTION
## What is this PR for?

Updates OS and ES versions to 2.6.0 and 8.6.2 respectively

## How have you tested this PR?

By creating a new cluster with:

- [ ] OpenSearch
- [ ] Elasticsearch

## What pages does it affect

New cluster page and cluster details page
<!-- List the pages that this PR can affect. If it is global change, try to add any side effects that it could have -->
