### PR TITLE
chore: update release version

### DIFF
--- a/src/pages/ClusterPage/new.js
+++ b/src/pages/ClusterPage/new.js
@@ -49,11 +49,11 @@ const openSearchVersions = ['2.6.0'];
 
 let interval;
 
-export const V7_ARC = '8.12.0-cluster';
-export const V6_ARC = '8.12.0-cluster';
-export const ARC_BYOC = '8.12.0-byoc';
+export const V7_ARC = '8.12.1-cluster';
+export const V6_ARC = '8.12.1-cluster';
+export const ARC_BYOC = '8.12.1-byoc';
 export const V5_ARC = 'v5-0.0.1';
-export const REACTIVESEARCH_BYOC = '8.12.0-byoc';
+export const REACTIVESEARCH_BYOC = '8.12.1-byoc';
 
 export const arcVersions = {
 	7: V7_ARC,

--- a/src/pages/ClusterPage/new.js
+++ b/src/pages/ClusterPage/new.js
@@ -49,11 +49,11 @@ const openSearchVersions = ['2.6.0'];
 
 let interval;
 
-export const V7_ARC = '8.10.1-cluster';
-export const V6_ARC = '8.10.1-cluster';
-export const ARC_BYOC = '8.10.1-byoc';
+export const V7_ARC = '8.12.0-cluster';
+export const V6_ARC = '8.12.0-cluster';
+export const ARC_BYOC = '8.12.0-byoc';
 export const V5_ARC = 'v5-0.0.1';
-export const REACTIVESEARCH_BYOC = '8.10.1-byoc';
+export const REACTIVESEARCH_BYOC = '8.12.0-byoc';
 
 export const arcVersions = {
 	7: V7_ARC,


### PR DESCRIPTION
## What is this PR for?

Updates ReactiveSearch API version to 8.12.0 - with AI features available

## How have you tested this PR?

- [x] Creating a cluster
- [x] Upgrading an existing cluster

## What pages does it affect

<!-- List the pages that this PR can affect. If it is global change, try to add any side effects that it could have -->
