### PR TITLE
Revert "hide sls cluster creation buttons"

### DIFF
--- a/src/pages/ClusterPage/ClusterPage.js
+++ b/src/pages/ClusterPage/ClusterPage.js
@@ -762,14 +762,14 @@ class ClusterPage extends Component {
 									</Button>
 								</Tooltip>
 							</Link>
-							{/* <Link to="/new/serverless-search">
+							<Link to="/new/serverless-search">
 								<Tooltip title="Serverless search is a geo-distributed search index, takes 1 min to get up and running">
 									{' '}
 									<Button size="large" type="primary" block>
 										<PlusOutlined /> Serverless Search
 									</Button>
 								</Tooltip>
-							</Link> */}
+							</Link>
 						</Col>
 					</Row>
 				</Header>

--- a/src/pages/ClusterPage/new.js
+++ b/src/pages/ClusterPage/new.js
@@ -849,7 +849,7 @@ class NewCluster extends Component {
 						<Col
 							md={6}
 							css={{
-								display: 'none',
+								display: 'flex',
 								flexDirection: 'column-reverse',
 								paddingBottom: 20,
 							}}


### PR DESCRIPTION
Reverts appbaseio/dashboard#525

Re-test Serverless Search and then enable it for dashboard