### PR TITLE
chore(release): update to latest reactivesearch-api and ES + OS releases

### DIFF
--- a/src/pages/ClusterPage/info.js
+++ b/src/pages/ClusterPage/info.js
@@ -59,7 +59,7 @@ const checkIfUpdateIsAvailable = (version, recipe) => {
 	return version && version !== V7_ARC.split('-')[0];
 };
 
-const NEW_ES_VERSIONS = { '7': '7.17.8', '8': '8.6.0', '2': '2.5.0' };
+const NEW_ES_VERSIONS = { '7': '7.17.10', '8': '8.8.1', '2': '2.8.0' };
 
 const checkIfESUpdateIsAvailable = version => {
 	const [majorVersion, minorVersion] = version.split('.');

--- a/src/pages/ClusterPage/utils/index.js
+++ b/src/pages/ClusterPage/utils/index.js
@@ -770,9 +770,9 @@ export function updateBackend(id, body) {
 export const SSH_KEY =
 	'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCVqOPpNuX53J+uIpP0KssFRZToMV2Zy/peG3wYHvWZkDvlxLFqGTikH8MQagt01Slmn+mNfHpg6dm5NiKfmMObm5LbcJ62Nk9AtHF3BPP42WyQ3QiGZCjJOX0fVsyv3w3eB+Eq+F+9aH/uajdI+wWRviYB+ljhprZbNZyockc6V33WLeY+EeRQW0Cp9xHGQUKwJa7Ch8/lRkNi9QE6n5W/T6nRuOvu2+ThhjiDFdu2suq3V4GMlEBBS6zByT9Ct5ryJgkVJh6d/pbocVWw99mYyVm9MNp2RD9w8R2qytRO8cWvTO/KvsAZPXj6nJtB9LaUtHDzxe9o4AVXxzeuMTzx siddharth@appbase.io';
 
-export const esVersions = ['8.7.1', '7.17.9'];
+export const esVersions = ['8.8.1', '7.17.10'];
 
-export const openSearchVersions = ['2.7.0'];
+export const openSearchVersions = ['2.8.0'];
 export const ansibleMachineMarks = {
 	[CLUSTER_PLANS.SANDBOX_2020]: {
 		label: PLAN_LABEL[CLUSTER_PLANS.SANDBOX_2020],
@@ -968,11 +968,11 @@ export const regionsKeyMap = {
 	other: 'other',
 };
 
-export const V7_ARC = '8.13.1-cluster';
-export const V6_ARC = '8.13.1-cluster';
-export const ARC_BYOC = '8.13.1-byoc';
+export const V7_ARC = '8.14.0-cluster';
+export const V6_ARC = '8.14.0-cluster';
+export const ARC_BYOC = '8.14.0-byoc';
 export const V5_ARC = 'v5-0.0.1';
-export const REACTIVESEARCH_BYOC = '8.13.1-byoc';
+export const REACTIVESEARCH_BYOC = '8.14.0-byoc';
 
 export const arcVersions = {
 	7: V7_ARC,

--- a/src/pages/DeployTemplate/index.js
+++ b/src/pages/DeployTemplate/index.js
@@ -43,7 +43,12 @@ const DeployTemplate = ({ location }) => {
 	};
 
 	const getFormData = dataUrl => {
-		fetch(dataUrl)
+		console.log('data url: ', dataUrl);
+		fetch(dataUrl, {
+			headers: {
+				Authorization: undefined,
+			},
+		})
 			.then(res => res.text())
 			.then(resp => {
 				const json = yaml.load(resp);

--- a/src/pages/DeployTemplate/index.js
+++ b/src/pages/DeployTemplate/index.js
@@ -43,12 +43,7 @@ const DeployTemplate = ({ location }) => {
 	};
 
 	const getFormData = dataUrl => {
-		console.log('data url: ', dataUrl);
-		fetch(dataUrl, {
-			headers: {
-				Authorization: undefined,
-			},
-		})
+		fetch(dataUrl)
 			.then(res => res.text())
 			.then(resp => {
 				const json = yaml.load(resp);


### PR DESCRIPTION
## What is this PR for?

Update release version of RS API, Elasticsearch and OpenSearch

- [x] RS API to 8.14.0
- [x] OpenSearch to 2.8.0
- [x] Elasticsearch to 7.17.10, 8.8.1

## How have you tested this PR?

<!-- Share the steps that you have followed to test this PR. Add loom video / gif / screenshot -->

## What pages does it affect

<!-- List the pages that this PR can affect. If it is global change, try to add any side effects that it could have -->
