### PR TITLE
Fix sls search engine config

### DIFF
--- a/src/pages/ClusterPage/NewMyServerlessSearch.js
+++ b/src/pages/ClusterPage/NewMyServerlessSearch.js
@@ -101,7 +101,7 @@ class NewMyCluster extends Component {
 			verifiedCluster: false,
 			isStripeCheckoutOpen: false,
 			activeKey: 'america',
-			backend: BACKENDS.ELASTICSEARCH.name,
+			backend: BACKENDS.System.name,
 			setSearchEngine: false,
 		};
 	}
@@ -218,7 +218,11 @@ class NewMyCluster extends Component {
 				document.getElementById('cluster-name').focus();
 			}
 
-			if (this.state.setSearchEngine && !this.state.clusterURL) {
+			if (
+				this.state.backend !== BACKENDS.System.name &&
+				this.state.setSearchEngine &&
+				!this.state.clusterURL
+			) {
 				this.setState({
 					error: 'Please enter URL',
 				});
@@ -602,7 +606,7 @@ class NewMyCluster extends Component {
 										onClick={() =>
 											this.setState({
 												setSearchEngine: false,
-												backend: '',
+												backend: BACKENDS.System.name,
 												clusterURL: '',
 											})
 										}
@@ -676,6 +680,9 @@ class NewMyCluster extends Component {
 																	this.setState(
 																		{
 																			backend,
+																			verifiedCluster: false,
+																			clusterURL:
+																				'',
 																		},
 																	);
 																}}
@@ -705,100 +712,116 @@ class NewMyCluster extends Component {
 												)}
 										</div>
 
-										<div
-											className="col grow vcenter"
-											css={{
-												flexDirection: 'column',
-												alignItems:
-													'flex-start !important',
-												justifyContent: 'center',
-											}}
-										>
-											<input
-												id="elastic-url"
-												type="name"
+										{this.state.backend !==
+											BACKENDS.System.name && (
+											<div
+												className="col grow vcenter"
 												css={{
-													width: '100%',
-													maxWidth: 400,
-													marginBottom: 10,
-													outline: 'none',
-													border:
-														isInvalidURL &&
-														this.state
-															.clusterURL !== ''
-															? '1px solid red'
-															: '1px solid #e8e8e8',
+													flexDirection: 'column',
+													alignItems:
+														'flex-start !important',
+													justifyContent: 'center',
 												}}
-												placeholder={`Enter your ${capitalizeWord(
-													this.state.backend,
-												)} URL`}
-												value={this.state.clusterURL}
-												onChange={e =>
-													this.setConfig(
-														'clusterURL',
-														e.target.value,
-													)
-												}
-											/>
-											<Button
-												onClick={this.handleVerify}
-												disabled={
-													!this.state.clusterURL
-												}
-												loading={verifyingURL}
 											>
-												Verify Connection
-											</Button>
-
-											{verifiedCluster ? (
-												<Tag
-													style={{ marginTop: 10 }}
-													color="green"
-												>
-													Verified Connection. Version
-													Detected: {clusterVersion}
-												</Tag>
-											) : null}
-
-											{isInvalidURL ? (
-												<p
-													style={{
-														color: 'red',
+												<input
+													id="elastic-url"
+													type="name"
+													css={{
+														width: '100%',
+														maxWidth: 400,
+														marginBottom: 10,
+														outline: 'none',
+														border:
+															isInvalidURL &&
+															this.state
+																.clusterURL !==
+																''
+																? '1px solid red'
+																: '1px solid #e8e8e8',
 													}}
+													placeholder={`Enter your ${capitalizeWord(
+														this.state.backend,
+													)} URL`}
+													value={
+														this.state.clusterURL
+													}
+													onChange={e =>
+														this.setConfig(
+															'clusterURL',
+															e.target.value,
+														)
+													}
+												/>
+												<Button
+													onClick={this.handleVerify}
+													disabled={
+														!this.state.clusterURL
+													}
+													loading={verifyingURL}
 												>
-													{urlErrorMessage ===
-													'Auth Error' ? (
-														<React.Fragment>
-															We received a
-															authentication
-															error. Does your
-															ElasticSearch
-															require additional
-															authentication? Read
-															more{' '}
-															<a
-																target="_blank"
-																rel="noopener noreferrer"
-																href="https://docs.reactivesearch.io/docs/hosting/BYOC/ConnectToYourElasticSearch"
-															>
-																here
-															</a>
-															.
-														</React.Fragment>
-													) : (
-														urlErrorMessage
-													)}
-												</p>
-											) : null}
-										</div>
+													Verify Connection
+												</Button>
+
+												{verifiedCluster ? (
+													<Tag
+														style={{
+															marginTop: 10,
+														}}
+														color="green"
+													>
+														Verified Connection.
+														Version Detected:{' '}
+														{clusterVersion}
+													</Tag>
+												) : null}
+
+												{isInvalidURL ? (
+													<p
+														style={{
+															color: 'red',
+														}}
+													>
+														{urlErrorMessage ===
+														'Auth Error' ? (
+															<React.Fragment>
+																We received a
+																authentication
+																error. Does your
+																ElasticSearch
+																require
+																additional
+																authentication?
+																Read more{' '}
+																<a
+																	target="_blank"
+																	rel="noopener noreferrer"
+																	href="https://docs.reactivesearch.io/docs/hosting/BYOC/ConnectToYourElasticSearch"
+																>
+																	here
+																</a>
+																.
+															</React.Fragment>
+														) : (
+															urlErrorMessage
+														)}
+													</p>
+												) : null}
+											</div>
+										)}
 									</div>
 								</div>
 							) : (
 								<Alert
-									message={`Serverless Search provides you with ${
-										machineMarks[this.state.pricing_plan]
-											.searchIndices
-									} geo-distributed search indexes on Elasticsearch out of the box.`}
+									message={
+										this.state.backend ===
+										BACKENDS.System.name
+											? 'System backend provides you with 2 geo-distributed search indexes on OpenSearch out of the box.'
+											: `Serverless Search provides you with ${
+													machineMarks[
+														this.state.pricing_plan
+													].searchIndices
+											  } geo-distributed search indexes on Elasticsearch out of the box.`
+									}
 									description={
 										<div
 											css={`
@@ -850,6 +873,13 @@ class NewMyCluster extends Component {
 									type="primary"
 									size="large"
 									onClick={this.createCluster}
+									disabled={
+										(this.state.setSearchEngine &&
+											this.state.backend !==
+												BACKENDS.System.name &&
+											!this.state.verifiedCluster) ||
+										!this.validateClusterName()
+									}
 								>
 									{isDeployTemplate ? (
 										<>

--- a/src/pages/ClusterPage/NewMyServerlessSearch.js
+++ b/src/pages/ClusterPage/NewMyServerlessSearch.js
@@ -815,7 +815,11 @@ class NewMyCluster extends Component {
 									message={
 										this.state.backend ===
 										BACKENDS.System.name
-											? 'System backend provides you with 2 geo-distributed search indexes on OpenSearch out of the box.'
+											? `System backend provides you with ${
+													machineMarks[
+														this.state.pricing_plan
+													].searchIndices
+											  } geo-distributed search indexes on OpenSearch out of the box.`
 											: `Serverless Search provides you with ${
 													machineMarks[
 														this.state.pricing_plan

--- a/src/pages/ClusterPage/NewMyServerlessSearch.js
+++ b/src/pages/ClusterPage/NewMyServerlessSearch.js
@@ -621,6 +621,15 @@ class NewMyCluster extends Component {
 									</Button>
 									<div className="col light">
 										<h3> Choose search engine </h3>
+										<p>
+											{`System backend provides you with ${
+												machineMarks[
+													this.state.pricing_plan
+												].searchIndices
+											}
+											geo-distributed search indexes on
+											OpenSearch out of the box.`}
+										</p>
 									</div>
 									<div>
 										<div
@@ -812,20 +821,10 @@ class NewMyCluster extends Component {
 								</div>
 							) : (
 								<Alert
-									message={
-										this.state.backend ===
-										BACKENDS.System.name
-											? `System backend provides you with ${
-													machineMarks[
-														this.state.pricing_plan
-													].searchIndices
-											  } geo-distributed search indexes on OpenSearch out of the box.`
-											: `Serverless Search provides you with ${
-													machineMarks[
-														this.state.pricing_plan
-													].searchIndices
-											  } geo-distributed search indexes on Elasticsearch out of the box.`
-									}
+									message={`Serverless Search provides you with ${
+										machineMarks[this.state.pricing_plan]
+											.searchIndices
+									} geo-distributed search indexes on Elasticsearch out of the box.`}
 									description={
 										<div
 											css={`

--- a/src/pages/ClusterPage/screens/ClusterScreen.js
+++ b/src/pages/ClusterPage/screens/ClusterScreen.js
@@ -87,6 +87,9 @@ class ClusterScreen extends Component {
 	componentDidMount() {
 		this.triggerPayment();
 		this.initClusters();
+		this.setState({
+			backend: this.props.cluster?.backend,
+		});
 	}
 
 	initClusters = () => {
@@ -95,10 +98,16 @@ class ClusterScreen extends Component {
 				const activeClusters = clusters.filter(
 					item => item.status === 'active' && item.role === 'admin',
 				);
+
+				const backendVal = clusters.find(
+					_ => _.id === this.props.clusterId,
+				).backend;
+
 				this.setState({
 					clustersAvailable: !!clusters.length,
 					clusters: activeClusters,
 					isClusterLoading: false,
+					...(backendVal ? { backend: backendVal } : {}),
 				});
 			})
 			.catch(e => {
@@ -819,6 +828,9 @@ class ClusterScreen extends Component {
 															onClick={() => {
 																this.setState({
 																	backend,
+																	clusterURL:
+																		'',
+																	verifiedCluster: false,
 																});
 															}}
 														>
@@ -1006,6 +1018,12 @@ class ClusterScreen extends Component {
 								icon={<SaveOutlined />}
 								type="primary"
 								onClick={this.saveClusterSettings}
+								disabled={
+									this.state.setSearchEngine &&
+									this.state.backend !==
+										BACKENDS.System.name &&
+									!this.state.verifiedCluster
+								}
 							>
 								Save Cluster Settings
 							</Button>

--- a/src/pages/ClusterPage/screens/ClusterScreen.js
+++ b/src/pages/ClusterPage/screens/ClusterScreen.js
@@ -771,6 +771,10 @@ class ClusterScreen extends Component {
 								</Button>
 								<div className="col light">
 									<h3> Choose search engine </h3>
+									<p>{`System backend provides you with ${
+										machineMarks[cluster.pricing_plan]
+											.searchIndices
+									} geo-distributed search indexes on OpenSearch out of the box.`}</p>
 								</div>
 								<div>
 									<div
@@ -947,19 +951,10 @@ class ClusterScreen extends Component {
 							</div>
 						) : (
 							<Alert
-								message={
-									this.state.backend === BACKENDS.System.name
-										? `System backend provides you with ${
-												machineMarks[
-													cluster.pricing_plan
-												].searchIndices
-										  } geo-distributed search indexes on OpenSearch out of the box.`
-										: `Serverless Search provides you with ${
-												machineMarks[
-													cluster.pricing_plan
-												].searchIndices
-										  } geo-distributed search indexes on Elasticsearch out of the box.`
-								}
+								message={`Serverless Search provides you with ${
+									machineMarks[cluster.pricing_plan]
+										.searchIndices
+								} geo-distributed search indexes on Elasticsearch out of the box.`}
 								description={
 									<div
 										css={`

--- a/src/pages/ClusterPage/screens/ClusterScreen.js
+++ b/src/pages/ClusterPage/screens/ClusterScreen.js
@@ -947,10 +947,19 @@ class ClusterScreen extends Component {
 							</div>
 						) : (
 							<Alert
-								message={`Serverless Search provides you with ${
-									machineMarks[cluster.pricing_plan]
-										.searchIndices
-								} geo-distributed search indexes on Elasticsearch out of the box.`}
+								message={
+									this.state.backend === BACKENDS.System.name
+										? `System backend provides you with ${
+												machineMarks[
+													cluster.pricing_plan
+												].searchIndices
+										  } geo-distributed search indexes on OpenSearch out of the box.`
+										: `Serverless Search provides you with ${
+												machineMarks[
+													cluster.pricing_plan
+												].searchIndices
+										  } geo-distributed search indexes on Elasticsearch out of the box.`
+								}
 								description={
 									<div
 										css={`


### PR DESCRIPTION
**PR Type:** Fix

**Description:**
This PR addresses configuration issues related to search engine backends for clusters. The changes are as follows:

**New cluster page:**
- The default backend is set to System. For the System backend, the URL input field is hidden, and the ElasticSearch backend is set instead. You can check an example of this configuration on the following URL: [Cluster Example](https://dashboard.appbase.io/clusters/test-rs-jun-16-3-dsqpbjc).
- The text on the new cluster page now states: "System backend provides you with 2 geo-distributed search indexes on OpenSearch out of the box."

**Cluster details page:**
- The backend displayed on the cluster details page reflects the configured backend. It always shows the value obtained from the `/v1/clusters` endpoint.

[Notion Link](https://www.notion.so/reactivesearch/SLS-configure-search-engine-bug-dd9bd8827d404a7795164a6c11bc4165)

[Video Link](https://www.loom.com/share/388a2e7b07a7472a8add95176b917e5b?sid=67da4d86-0545-4469-9cb2-89802e3fe469)