### PR TITLE
Add support for using AccAPI to get github pipeline content

### DIFF
--- a/src/pages/DeployTemplate/DeployCluster.js
+++ b/src/pages/DeployTemplate/DeployCluster.js
@@ -77,7 +77,13 @@ const DeployCluster = ({
 					},
 					body: formData,
 				};
-				fetch(`${url}_pipeline`, obj)
+
+				// If the `url` doesn't end with a `/`, add it.
+				const urlToHit = `${url}${
+					url.endsWith('/') ? '' : '/'
+				}_pipeline`;
+
+				fetch(urlToHit, obj)
 					.then(response => response.json())
 					.then(json => {
 						if (json?.error) {

--- a/src/pages/DeployTemplate/index.js
+++ b/src/pages/DeployTemplate/index.js
@@ -10,6 +10,7 @@ import DeployLogs from './DeployLogs';
 import Loader from '../../components/Loader';
 import FullHeader from '../../components/FullHeader';
 import Header from '../../components/Header';
+import { ACC_API } from '../../batteries/utils';
 
 const yaml = require('js-yaml');
 
@@ -43,6 +44,13 @@ const DeployTemplate = ({ location }) => {
 	};
 
 	const getFormData = dataUrl => {
+		// Build the URL to hit AccAPI to get the template
+		// details
+		dataUrl = `${ACC_API}/v2/raw-github?path=${dataUrl.replace(
+			'https://raw.githubusercontent.com/',
+			'',
+		)}`;
+
 		fetch(dataUrl)
 			.then(res => res.text())
 			.then(resp => {


### PR DESCRIPTION
## What is this PR for?

<!-- Brief description of feature / bug fix that this PR do. -->

This PR adds support to use AccAPI's proxy URL to get content from GitHub instead of hitting rawgithub directly since that leads to a CORS error.

<!--

<!--  Link to Notion card / Github issue -->

## How have you tested this PR?

<!-- Share the steps that you have followed to test this PR. Add loom video / gif / screenshot -->

- Tested locally with a pipeline template

## What pages does it affect

<!-- List the pages that this PR can affect. If it is global change, try to add any side effects that it could have -->

Effects the `/deploy` route page.
