### PR TITLE
version automation and compare pre-release versions in semver

### DIFF
--- a/src/pages/ClusterPage/NewMyCluster.js
+++ b/src/pages/ClusterPage/NewMyCluster.js
@@ -25,8 +25,7 @@ import {
 	BACKENDS,
 	capitalizeWord,
 	regionsKeyMap,
-	REACTIVESEARCH_BYOC,
-	ARC_BYOC,
+	arc,
 } from './utils';
 import { regions, regionsByPlan } from './utils/regions';
 import { clusterContainer, card, fadeOutStyles, settingsItem } from './styles';
@@ -266,11 +265,11 @@ class NewMyCluster extends Component {
 			const body = {
 				url: this.state.clusterURL,
 				backend: this.state.backend,
-				reactivesearch_image: REACTIVESEARCH_BYOC,
+				reactivesearch_image: `${arc}-byoc`,
 				cluster_name: this.state.clusterName,
 				pricing_plan: this.state.pricing_plan,
 				location: this.state.region,
-				arc_image: ARC_BYOC,
+				arc_image: `${arc}-byoc`,
 				is_multi_zone: false,
 				...obj,
 			};

--- a/src/pages/ClusterPage/info.js
+++ b/src/pages/ClusterPage/info.js
@@ -50,51 +50,50 @@ import { getUrlParams } from '../../utils/helper';
 import StripeCheckout from '../../components/StripeCheckout';
 
 function isGreaterVersion(ver1, ver2) {
-    // Split based on '-' to handle pre-release strings
-    const [v1Main, v1PreRelease] = ver1.split('-');
-    const [v2Main, v2PreRelease] = ver2.split('-');
+	console.log('comparing between: ', ver1, ver2);
+	// Split based on '-' to handle pre-release strings
+	const [v1Main, v1PreRelease] = ver1.split('-');
+	const [v2Main, v2PreRelease] = ver2.split('-');
 
-    const v1Parts = v1Main.split('.').map(Number);
-    const v2Parts = v2Main.split('.').map(Number);
+	const v1Parts = v1Main.split('.').map(Number);
+	const v2Parts = v2Main.split('.').map(Number);
 
-    for (let i = 0; i < v1Parts.length; i++) {
-        if (v1Parts[i] > v2Parts[i]) {
-            return true;
-        }
-        if (v1Parts[i] < v2Parts[i]) {
-            return false;
-        }
-    }
+	for (let i = 0; i < v1Parts.length; i++) {
+		if (v1Parts[i] > v2Parts[i]) {
+			return true;
+		}
+		if (v1Parts[i] < v2Parts[i]) {
+			return false;
+		}
+	}
 
-    // At this point, the main version numbers are equal, so we check the pre-release strings
-    if (v1PreRelease && !v2PreRelease) {
-        // ver2 is greater since it doesn't have a pre-release string
-        return false;
-    }
-    if (!v1PreRelease && v2PreRelease) {
-        // ver1 is greater since it doesn't have a pre-release string
-        return true;
-    }
-    if (v1PreRelease && v2PreRelease) {
-        const v1PreParts = v1PreRelease.split('.');
-        const v2PreParts = v2PreRelease.split('.');
-        for (let i = 0; i < Math.max(v1PreParts.length, v2PreParts.length); i++) {
-            const v1Segment = v1PreParts[i] || '';
-            const v2Segment = v2PreParts[i] || '';
-            if (isNaN(v1Segment) && isNaN(v2Segment)) {
-                if (v1Segment > v2Segment) return true;
-                if (v1Segment < v2Segment) return false;
-            } else if (!isNaN(v1Segment) && !isNaN(v2Segment)) {
-                if (Number(v1Segment) > Number(v2Segment)) return true;
-                if (Number(v1Segment) < Number(v2Segment)) return false;
-            } else {
-                return isNaN(v1Segment);
-            }
-        }
-    }
+	// At this point, the main version numbers are equal, so we check the pre-release strings
+	if (v1PreRelease && !v2PreRelease) {
+		// ver2 is greater since it doesn't have a pre-release string
+		return false;
+	}
+	if (!v1PreRelease && v2PreRelease) {
+		// ver1 is greater since it doesn't have a pre-release string
+		return true;
+	}
+	if (ver1 === ver2) {
+		return false;
+	}
+	if (v1Parts.length < v2Parts.length) {
+		return true;
+	} else if (v1Parts.length > v2Parts.length) {
+		return false;
+	}
+	// case where both versions have pre-release strings
+	if ((v1PreRelease && v2PreRelease) || (!v1PreRelease && !v2PreRelease)) {
+		const v1PreParts = ver1.split('.')[v1Parts.length - 1];
+		const v2PreParts = ver2.split('.')[v2Parts.length - 1];
+		if (v1PreParts > v2PreParts) return true;
+		if (v1PreParts < v2PreParts) return false;
+	}
 
-    // If we reach here, the versions are exactly equal or their differences are inconclusive
-    return false;
+	// If we reach here, the versions differences are inconclusive
+	return false;
 }
 
 const checkIfUpdateIsAvailable = (version, recipe) => {

--- a/src/pages/ClusterPage/info.js
+++ b/src/pages/ClusterPage/info.js
@@ -38,8 +38,6 @@ import {
 	PRICE_BY_PLANS,
 	isSandBoxPlan,
 	ansibleMachineMarks,
-	V7_ARC,
-	ARC_BYOC,
 	arc,
 	elasticsearch_7x,
 	elasticsearch_8x,
@@ -97,20 +95,8 @@ function isGreaterVersion(ver1, ver2) {
 }
 
 const checkIfUpdateIsAvailable = (version, recipe) => {
-	const k8sVersion = (version.split('/')[1] || '').split(':')[1];
-
-	if (recipe === 'byoc') {
-		return version && version !== ARC_BYOC.split('-')[0];
-	}
-
-	if (k8sVersion) {
-		return k8sVersion !== V7_ARC;
-	}
-
 	return version && isGreaterVersion(arc, version);
 };
-
-const NEW_ES_VERSIONS = { '7': '7.17.10', '8': '8.8.1', '2': '2.8.0' };
 
 const getSearchVersion = version => {
 	const majorVersion = version.split('.')[0];
@@ -144,17 +130,8 @@ const getSearchEngine = version => {
 
 const checkIfESUpdateIsAvailable = version => {
 	const [majorVersion, minorVersion] = version.split('.');
-
-	if (NEW_ES_VERSIONS[majorVersion]) {
-		if (
-			Number(minorVersion) <
-			Number(NEW_ES_VERSIONS[majorVersion].split('.')[1])
-		) {
-			return NEW_ES_VERSIONS[majorVersion];
-		}
-	}
-
-	return false;
+	const latestVersion = getSearchVersion(version);
+	return version && isGreaterVersion(latestVersion, version);
 };
 
 class ClusterInfo extends Component {
@@ -440,7 +417,8 @@ class ClusterInfo extends Component {
 			const url = `${ACC_API}/v2/_deploy/${id}`;
 			const body = {
 				arc: {
-					version: recipe === 'byoc' ? ARC_BYOC : V7_ARC,
+					version:
+						recipe === 'byoc' ? `${arc}-byoc` : `${arc}-cluster`,
 					status: 'restarted',
 				},
 			};

--- a/src/pages/ClusterPage/new.js
+++ b/src/pages/ClusterPage/new.js
@@ -28,12 +28,13 @@ import {
 	EFFECTIVE_PRICE_BY_PLANS,
 	PRICE_BY_PLANS,
 	getDistance,
-	openSearchVersions,
-	esVersions,
 	SSH_KEY,
 	ansibleMachineMarks,
 	regionsKeyMap,
-	arcVersions,
+	arc as arc_version,
+	opensearch as opensearch_version,
+	elasticsearch_7x,
+	elasticsearch_8x,
 } from './utils';
 import plugins from './utils/plugins';
 import { regions, regionsByPlan } from './utils/regions';
@@ -86,7 +87,7 @@ class NewCluster extends Component {
 			isLoading: false,
 			clusterName: '',
 			changed: false,
-			clusterVersion: openSearchVersions[0],
+			clusterVersion: opensearch_version,
 			pricing_plan,
 			vm_size: get(
 				ansibleMachineMarks[pricing_plan],
@@ -348,9 +349,7 @@ class NewCluster extends Component {
 			const selectedMachine =
 				ansibleMachineMarks[this.state.pricing_plan];
 
-			const arcTag =
-				arcVersions[this.state.clusterVersion.split('.')[0]] ||
-				arcVersions['6'];
+			const arcTag = `${arc_version}-cluster`;
 
 			const body = {
 				elasticsearch: {
@@ -657,8 +656,8 @@ class NewCluster extends Component {
 		if (isLoading) return <Loader />;
 		const versions =
 			this.state.esFlavor === 'opensearch'
-				? openSearchVersions
-				: esVersions;
+				? [opensearch_version]
+				: [elasticsearch_8x, elasticsearch_7x];
 		const defaultVersion = this.state.clusterVersion;
 
 		const activeClusters = clusters.filter(
@@ -1034,7 +1033,7 @@ class NewCluster extends Component {
 												);
 												this.setConfig(
 													'clusterVersion',
-													openSearchVersions[0],
+													opensearch_version,
 												);
 											}}
 										>
@@ -1074,7 +1073,7 @@ class NewCluster extends Component {
 												);
 												this.setConfig(
 													'clusterVersion',
-													esVersions[0],
+													elasticsearch_7x,
 												);
 											}}
 										>

--- a/src/pages/ClusterPage/screens/ClusterScreen.js
+++ b/src/pages/ClusterPage/screens/ClusterScreen.js
@@ -30,7 +30,7 @@ import {
 	capitalizeWord,
 	verifyCluster,
 	updateBackend,
-	V7_ARC,
+	arc as arc_version,
 } from '../utils';
 import { machineMarks } from '../NewMyServerlessSearch';
 
@@ -268,7 +268,7 @@ class ClusterScreen extends Component {
 					...body.addons,
 					{
 						name: 'arc',
-						image: `siddharthlatest/arc:${V7_ARC}`,
+						image: `siddharthlatest/arc:${arc_version}-cluster`,
 						exposed_port: 8000,
 					},
 				];

--- a/src/pages/ClusterPage/utils/index.js
+++ b/src/pages/ClusterPage/utils/index.js
@@ -827,9 +827,6 @@ export function updateBackend(id, body) {
 export const SSH_KEY =
 	'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCVqOPpNuX53J+uIpP0KssFRZToMV2Zy/peG3wYHvWZkDvlxLFqGTikH8MQagt01Slmn+mNfHpg6dm5NiKfmMObm5LbcJ62Nk9AtHF3BPP42WyQ3QiGZCjJOX0fVsyv3w3eB+Eq+F+9aH/uajdI+wWRviYB+ljhprZbNZyockc6V33WLeY+EeRQW0Cp9xHGQUKwJa7Ch8/lRkNi9QE6n5W/T6nRuOvu2+ThhjiDFdu2suq3V4GMlEBBS6zByT9Ct5ryJgkVJh6d/pbocVWw99mYyVm9MNp2RD9w8R2qytRO8cWvTO/KvsAZPXj6nJtB9LaUtHDzxe9o4AVXxzeuMTzx siddharth@appbase.io';
 
-export const esVersions = ['8.9.0', '7.17.10'];
-
-export const openSearchVersions = ['2.9.0'];
 export const ansibleMachineMarks = {
 	[CLUSTER_PLANS.SANDBOX_2020]: {
 		label: PLAN_LABEL[CLUSTER_PLANS.SANDBOX_2020],
@@ -1023,20 +1020,4 @@ export const regionsKeyMap = {
 	eu: 'europe',
 	us: 'america',
 	other: 'other',
-};
-
-export const V7_ARC = '8.18.0-cluster';
-export const V6_ARC = '8.18.0-cluster';
-export const ARC_BYOC = '8.18.0-byoc';
-export const V5_ARC = 'v5-0.0.1';
-export const REACTIVESEARCH_BYOC = '8.17.0-byoc';
-
-export const arcVersions = {
-	7: V7_ARC,
-	6: V6_ARC,
-	5: V5_ARC,
-	/* odfe versions start */
-	0: V6_ARC,
-	1: V7_ARC,
-	/* odfe versions end */
 };


### PR DESCRIPTION
## What is this PR for?

Update auto version banner to account for pre-release versions. One assumption in this PR is that supported versions remain accessible via an ACCAPI endpoint. However, this is an okay assumption as everything in dashboard relies on ACCAPI.

## How have you tested this PR?

- [x] Comparing semver with sember
- [x] Comparing semver with pre-release version
- [x] Create a new cluster

<!-- Share the steps that you have followed to test this PR. Add loom video / gif / screenshot -->

## What pages does it affect

<!-- List the pages that this PR can affect. If it is global change, try to add any side effects that it could have -->
- [x] Cluster detail page
- [x] New cluster page
